### PR TITLE
Added concatenation of last layers

### DIFF
--- a/expts/main_run_get_fingerprints.py
+++ b/expts/main_run_get_fingerprints.py
@@ -26,7 +26,7 @@ os.chdir(MAIN_DIR)
 def main() -> None:
 
     LIST_CONCAT_LAST_LAYERS = [1, 0, [1, 2], [0, 1, 2]]
-    DATA_NAME_ALL = ["molbace"] #, "mollipo", "moltox21", "molHIV"]
+    DATA_NAME_ALL = ["molbace"]  # , "mollipo", "moltox21", "molHIV"]
     MODEL_PATH = "gs://goli-public/pretrained-models"
     MODEL_NAME = "goli-zinc-micro-dummy-test"
     MODEL_FILE = f"{MODEL_PATH}/{MODEL_NAME}/model.ckpt"
@@ -39,7 +39,6 @@ def main() -> None:
 
     for data_name in DATA_NAME_ALL:
         DATA_CONFIG = f"{MAIN_DIR}/expts/config_{data_name}_pretrained.yaml"
-
 
         with fsspec.open(DATA_CONFIG, "r") as f:
             data_cfg = yaml.safe_load(f)

--- a/goli/nn/architectures.py
+++ b/goli/nn/architectures.py
@@ -1000,7 +1000,7 @@ class FullDGLNetwork(nn.Module):
                 # Useful for generating fingerprints
                 h = [h]
                 for ii in range(len(self.post_nn.layers)):
-                    h.insert(0, self.post_nn.layers[ii].forward(h[0])) # Append in reverse order
+                    h.insert(0, self.post_nn.layers[ii].forward(h[0]))  # Append in reverse order
                 h = torch.cat([h[ii] for ii in self._concat_last_layers], dim=-1)
 
         return h


### PR DESCRIPTION
Checklist:

- Added ability to select or concatenate the last layers of the GNN, without having to drop the layers.
- This will be faster than reloading the model each time we want to keep a different layer
- Does not require `X` inferences to generate a concatenation of the output of `X` different layers.
- Made compatible with **molfeat** in this [latest pull request](https://github.com/valence-platform/molfeat/pull/42)

---
