### PR TITLE
Make sure that output of self-attention in `GraphGPSPyg` is not overwritten

### DIFF
--- a/goli/nn/pyg_layers/gps_pyg.py
+++ b/goli/nn/pyg_layers/gps_pyg.py
@@ -155,7 +155,7 @@ class GPSLayerPyg(BaseGraphModule):
                 h, batch.batch, max_num_nodes_per_graph=max_num_nodes_per_graph, drop_nodes_last_graph=on_ipu
             )
             h_attn = self._sa_block(h_dense, None, ~mask)
-            h_attn = to_sparse_batch(h_dense, idx)
+            h_attn = to_sparse_batch(h_attn, idx)
 
             # Dropout, residual, norm
             h_attn = self.dropout_attn(h_attn)


### PR DESCRIPTION
Checklist:

- [ ] Added a `news` entry: _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

The variable `h_attn` is overwritten so the output of the self-attention layer is lost - this PR fixes that. I'm not sure if what I've got now is completely correct (need to get a bit more familiar with the GPS architecture)