### PR TITLE
replace max with amax

### DIFF
--- a/goli/nn/architectures/global_architectures.py
+++ b/goli/nn/architectures/global_architectures.py
@@ -1261,7 +1261,7 @@ class FullGraphNetwork(nn.Module):
         elif pooling == "mean":
             pooled = torch.mean(h, dim=dim)
         elif pooling == "max":
-            pooled = torch.max(h, dim=dim).values
+            pooled = torch.amax(h, dim=dim)
         else:
             raise Exception(f"Pooling method `{self.pe_pool}` is not defined")
         return pooled


### PR DESCRIPTION
This PR fixes #154 

`torch.max` is lowered by PopTorch to an op in [Poplibs](https://github.com/graphcore/poplibs) that was not being properly planned by the compiler. As a result, all of the variable data for the op was being placed on tile0, despite the remaining tiles having plenty of available memory. We'll update the implementation in Poplibs to better balance the data across the tiles. 

However, as you don't seem to be using `indices` returned by torch.max, just the `values`, you can try replacing `torch.max` with `torch.amax`, which uses just the values and has the correct tile mapping in Poplibs. This fits batch size 64 in memory with a balanced distribution across tiles.

![Screenshot 2022-11-16 at 11 21 51](https://user-images.githubusercontent.com/2728718/202167503-c5c447e4-ff9d-4b84-8559-c4f44824f3aa.png)

