### PR TITLE
GPS layer: restore dropout and droppath

### DIFF
--- a/goli/nn/pyg_layers/gps_pyg.py
+++ b/goli/nn/pyg_layers/gps_pyg.py
@@ -154,7 +154,7 @@ class GPSLayerPyg(BaseGraphModule):
             depth=2,
             activation=activation,
             dropout=self.dropout,
-            last_dropout=self.dropout
+            last_dropout=self.dropout,
         )
         self.f_out = FCLayer(in_dim, out_dim, normalization=normalization)
 


### PR DESCRIPTION
I was looking at an IPU program memory change and noticed that following the refactor of the PyG GPS layer there was a dropout missing on the second linear layer of the FF block and that drop path was being applied after the residual connection, when previously it was applied before.

Let me know if these changes make sense  
