### PR TITLE
Adding numIOTiles and PrefetchBufferDepth to IPU config

### DIFF
--- a/expts/configs/ipu.config
+++ b/expts/configs/ipu.config
@@ -2,3 +2,5 @@ deviceIterations(1)
 replicationFactor(1)
 enableProfiling("graph_analyser")       # The folder where the profile will be stored
 enableExecutableCaching("pop_compiler_cache")
+TensorLocations.numIOTiles(128)
+_Popart.set("defaultPrefetchBufferingDepth", 256)


### PR DESCRIPTION
Adding two options to the IPU config file. 

* numIOTiles - the number of tiles on the IPU to be designated as I/O tiles, this helps overlap compute and data transfer in time
* defaultPrefetchBufferingDepth - allows the Infeed to prefetch more data as soon as it is free so that data is readily available for compute


Checklist:

- [x] Still to set values for full sized model
- [ ] Added a `news` entry: _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---
