### PR TITLE
Improvements to `MLPEncoder`

### DIFF
--- a/goli/nn/encoders/mlp_encoder.py
+++ b/goli/nn/encoders/mlp_encoder.py
@@ -55,7 +55,7 @@ class MLPEncoder(BaseEncoder):
 
         # Currently only used by make_mup_base_kwargs
         #    so no need to call get_norm
-        self.normalization = normalization
+        self.normalization_argument = normalization
 
         # Initialize the MLP
         self.pe_encoder = MLP(
@@ -116,7 +116,7 @@ class MLPEncoder(BaseEncoder):
             dict(
                 hidden_dim=round(self.hidden_dim / divide_factor),
                 dropout=self.dropout,
-                normalization=self.normalization,
+                normalization=self.normalization_argument,
             )
         )
         return base_kwargs


### PR DESCRIPTION
Fixed `output_keys` type hint and the case when normalisation is used.

For the type hint, the following fails on `master`:
```python
from goli.nn.encoders.mlp_encoder import MLPEncoder

encoder = MLPEncoder(
    input_keys=["foo"],
    output_keys="bar",
    in_dim=64,
    hidden_dim=64,
    out_dim=64,
    num_layers=2,
)
```

For the normalisation, the following fails on `master` and works with this PR:
```python
from goli.nn.encoders.mlp_encoder import MLPEncoder

encoder = MLPEncoder(
    input_keys=["foo"],
    output_keys=["bar"],
    in_dim=64,
    hidden_dim=64,
    out_dim=64,
    num_layers=2,
    normalization="layer_norm"
)
```

---

Checklist:

- [ ] Added a `news` entry: _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---
