### PR TITLE
Use output keys in `MLPEncoder`

### DIFF
--- a/goli/nn/encoders/mlp_encoder.py
+++ b/goli/nn/encoders/mlp_encoder.py
@@ -125,8 +125,8 @@ class MLPEncoder(BaseEncoder):
 
         # Run the MLP for each input key
         output = {}
-        for key in input_keys:
-            output[key] = self.pe_encoder(batch[key])  # (Num nodes) x dim_pe
+        for input_key, output_key in zip(input_keys, self.output_keys):
+            output[output_key] = self.pe_encoder(batch[input_key])  # (Num nodes) x dim_pe
 
         return output
 


### PR DESCRIPTION
Note: this is based on my interpretation of how the `EncoderManager` and `MLPEncoder` are meant to work. Specifically, based on the `parse_output_keys` method of `MLPEncoder`, it looks like the input and output keys are meant to correspond. With this diff, in `config_pcqm_gpspp.yaml`, the outputs of the `MLPEncoder` on the random walk are included in the pooling operation for `"feat"`.