### PR TITLE
change torch sharing strategy

### DIFF
--- a/goli/data/datamodule.py
+++ b/goli/data/datamodule.py
@@ -41,6 +41,8 @@ from goli.data.smiles_transform import (
 from goli.data.collate import goli_collate_fn
 import goli.data.dataset as Datasets
 
+torch.multiprocessing.set_sharing_strategy("file_system")
+
 PCQM4M_meta = {
     "num tasks": 1,
     "eval metric": "mae",


### PR DESCRIPTION
Changes the way torch tensors are shared between processes. Using filesystem option writes the tensors to shared memory and only serialises the filename between processes.
For some unknown reason setting this option in dataset.py doesn't produce any effects. This options needs to be set in datamodule.py