### PR TITLE
enable loss scaling

### DIFF
--- a/expts/configs/config_mpnn_10M_pcqm4m.yaml
+++ b/expts/configs/config_mpnn_10M_pcqm4m.yaml
@@ -183,6 +183,7 @@ predictor:
     lr: 4.e-4 # warmup can be scheduled using torch_scheduler_kwargs
     # weight_decay: 1.e-7
   torch_scheduler_kwargs:
+    loss_scaling: 1024
     module_type: WarmUpLinearLR
     max_num_epochs: &max_epochs 100
     warmup_epochs: 10


### PR DESCRIPTION
in TF2 loss scaling is set to 1024. In GOLI it's just a matter of setting that in the config. 
