### PR TITLE
fix config

### DIFF
--- a/expts/configs/config_mpnn_10M_pcqm4m.yaml
+++ b/expts/configs/config_mpnn_10M_pcqm4m.yaml
@@ -183,8 +183,8 @@ predictor:
   optim_kwargs:
     lr: 4.e-4 # warmup can be scheduled using torch_scheduler_kwargs
     # weight_decay: 1.e-7
-  torch_scheduler_kwargs:
     loss_scaling: 1024
+  torch_scheduler_kwargs:
     module_type: WarmUpLinearLR
     max_num_epochs: &max_epochs 100
     warmup_epochs: 10


### PR DESCRIPTION
There is a small issue with the pcqm config and loss scaling. I think this comes from some merge conflict.
In master the loss_scaling attribute is being passed to the scheduler rather than the optimizer. This PR fixes that