### PR TITLE
Epoch time

### DIFF
--- a/goli/trainer/predictor.py
+++ b/goli/trainer/predictor.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Any, Union, Any, Callable, Tuple, Type, Optional
 import numpy as np
 from copy import deepcopy
 import time
+from loguru import logger
 
 import torch
 from torch import nn, Tensor
@@ -488,10 +489,12 @@ class PredictorModule(pl.LightningModule):
         self.epoch_start_time = time.time()
 
     def on_train_epoch_end(self) -> None:
-        assert self.epoch_start_time is not None, "epoch timer not initialized"
-        epoch_time = time.time() - self.epoch_start_time
-        self.epoch_start_time = None
-        self.log("epoch_time", torch.tensor(epoch_time))
+        if self.epoch_start_time is None:
+            logger.warning("epoch timer not initialized")
+        else:
+            epoch_time = time.time() - self.epoch_start_time
+            self.epoch_start_time = None
+            self.log("epoch_time", torch.tensor(epoch_time))
 
     def training_epoch_end(self, outputs: Dict):
         """


### PR DESCRIPTION
tracks and logs epoch time.
The epoch time includes both training and validation times, since in PTL the order of execution is as follows:
```
trainer.on_train_epoch_start()
for batch in train_dataloader:
    # training loop
trainer.on_validation_epoch_start()
for batch in val_dataloader:
    # validation loop
trainer.on_validation_epoch_end()
trainer.on_train_epoch_end()
```
