### PR TITLE
Adjust `Pad` transform to account for new `BaseTransform` class

### DIFF
--- a/goli/ipu/ipu_dataloader.py
+++ b/goli/ipu/ipu_dataloader.py
@@ -342,10 +342,10 @@ class Pad(BaseTransform):
         return num_nodes, num_edges
 
     def __call__(self, batch: Batch) -> Batch:
-        return _call(batch)
+        return self._call(batch)
 
     def forward(self, batch: Batch) -> Batch:
-        return _call(batch)
+        return self._call(batch)
 
     def _call(self, batch: Batch) -> Batch:
         """


### PR DESCRIPTION
Checklist:

- [ ] Added a `news` entry: _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

The `BaseTransform` class from `torch_geometric` was recently changed so that we need to implement `forward` instead of `__call__`. This new implementation will work regardless of whether we need `__call__` or `forward`. I've messaged the PyTorch Geometric team to let them know that this has happened so it might happen to others.