### PR TITLE
Raise original error if `poptorch` cannot be imported

### DIFF
--- a/graphium/ipu/ipu_utils.py
+++ b/graphium/ipu/ipu_utils.py
@@ -25,11 +25,9 @@ def import_poptorch(raise_error=True) -> Optional[ModuleType]:
         import poptorch
 
         return poptorch
-    except ImportError:
+    except ImportError as e:
         if raise_error:
-            raise ImportError(
-                "You must install poptorch and have IPU hardware. Check the GraphCore support https://www.graphcore.ai/support"
-            )
+            raise e
         return
 
 


### PR DESCRIPTION
Making this change because the original PopTorch error has better information about how to resolve the issue.

## Changelogs

- Raise upstream PopTorch error if `import poptorch` fails

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
