### PR TITLE
Pin `pydantic` to `<2` cuz of `lightning`

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -47,6 +47,7 @@ dependencies:
   # Optional deps
   - sympy
   - tensorboard
+  - pydantic <2  # because of lightning. See https://github.com/Lightning-AI/lightning/issues/18026 and https://github.com/Lightning-AI/lightning/pull/18022
 
   # Dev
   - pytest >=6.0


### PR DESCRIPTION
## Changelogs

- Pin `pydantic` to `<2` cuz of `lightning`. See https://github.com/Lightning-AI/lightning/pull/18022 and https://github.com/Lightning-AI/lightning/issues/18026. 

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
