### PR TITLE
Fail if hardware not available

### DIFF
--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -51,7 +51,7 @@ def get_accelerator(
     if accelerator_type == "ipu":
         poptorch = import_poptorch()
         if not poptorch.ipuHardwareIsAvailable():
-            logger.warning(
+            raise ValueError(
                 "IPUs selected, but no IPU is available/visible on this device. "
                 "If you do have IPUs, please check that the IPUOF_VIPU_API_PARTITION_ID and "
                 "IPUOF_VIPU_API_HOST environment variables are set."

--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -45,15 +45,17 @@ def get_accelerator(
 
     # Get the GPU info
     if (accelerator_type == "gpu") and (not torch.cuda.is_available()):
-        logger.warning(f"GPUs selected, but will be ignored since no GPU are available on this device")
-        accelerator_type = "cpu"
+        raise ValueError(f"GPUs selected, but GPUs are not available on this device")
 
     # Get the IPU info
     if accelerator_type == "ipu":
         poptorch = import_poptorch()
         if not poptorch.ipuHardwareIsAvailable():
-            logger.warning(f"IPUs selected, but will be ignored since no IPU are available on this device")
-            accelerator_type = "cpu"
+            logger.warning(
+                "IPUs selected, but no IPU is available/visible on this device. "
+                "If you do have IPUs, please check that the IPUOF_VIPU_API_PARTITION_ID and "
+                "IPUOF_VIPU_API_HOST environment variables are set."
+            )
 
     # Fall on cpu at the end
     if accelerator_type is None:

--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -50,6 +50,8 @@ def get_accelerator(
     # Get the IPU info
     if accelerator_type == "ipu":
         poptorch = import_poptorch()
+        if poptorch is None:
+            raise ValueError("IPUs selected, but PopTorch is not available")
         if not poptorch.ipuHardwareIsAvailable():
             raise ValueError(
                 "IPUs selected, but no IPU is available/visible on this device. "


### PR DESCRIPTION
## Changelogs

- Trying to use accelerator hardware when it is not available now issues an error instead of a warning. This prevents situations where accelerator-specific options are used but unavailable, causing non-obvious errors to occur.

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
