### PR TITLE
Using 16-true precision

### DIFF
--- a/expts/neurips2023_configs/debug/config_large_gcn_debug.yaml
+++ b/expts/neurips2023_configs/debug/config_large_gcn_debug.yaml
@@ -25,7 +25,7 @@ accelerator:
         loss_scaling: 1024
     trainer:
       trainer:
-        precision: 16
+        precision: 16-true
         accumulate_grad_batches: 4
 
   ipu_config:

--- a/expts/neurips2023_configs/debug/config_small_gcn_debug.yaml
+++ b/expts/neurips2023_configs/debug/config_small_gcn_debug.yaml
@@ -25,7 +25,7 @@ accelerator:
         loss_scaling: 1024
     trainer:
       trainer:
-        precision: 16
+        precision: 16-true
         accumulate_grad_batches: 1
 
   ipu_config:

--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -123,7 +123,7 @@ def load_datamodule(
             model_name=config["constants"]["name"],
             gradient_accumulation=config["trainer"]["trainer"].get("accumulate_grad_batches", None),
             ipu_inference_opts=ipu_inference_opts,
-            precision=config["trainer"]["trainer"].get("precision")
+            precision=config["trainer"]["trainer"].get("precision"),
         )
         # Define the Dataloader options for the IPU on the training sets
         bz_train = cfg_data["batch_size_training"]
@@ -367,7 +367,7 @@ def load_trainer(
             seed=config["constants"]["seed"],
             model_name=config["constants"]["name"],
             gradient_accumulation=config["trainer"]["trainer"].get("accumulate_grad_batches", None),
-            precision=config["trainer"]["trainer"].get("precision")
+            precision=config["trainer"]["trainer"].get("precision"),
         )
 
         from lightning_graphcore import IPUStrategy

--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -123,7 +123,7 @@ def load_datamodule(
             model_name=config["constants"]["name"],
             gradient_accumulation=config["trainer"]["trainer"].get("accumulate_grad_batches", None),
             ipu_inference_opts=ipu_inference_opts,
-            precision=config["trainer"]["trainer"]["precision"]
+            precision=config["trainer"]["trainer"].get("precision")
         )
         # Define the Dataloader options for the IPU on the training sets
         bz_train = cfg_data["batch_size_training"]
@@ -367,7 +367,7 @@ def load_trainer(
             seed=config["constants"]["seed"],
             model_name=config["constants"]["name"],
             gradient_accumulation=config["trainer"]["trainer"].get("accumulate_grad_batches", None),
-            precision=config["trainer"]["trainer"]["precision"]
+            precision=config["trainer"]["trainer"].get("precision")
         )
 
         from lightning_graphcore import IPUStrategy

--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -123,6 +123,7 @@ def load_datamodule(
             model_name=config["constants"]["name"],
             gradient_accumulation=config["trainer"]["trainer"].get("accumulate_grad_batches", None),
             ipu_inference_opts=ipu_inference_opts,
+            precision=config["trainer"]["trainer"]["precision"]
         )
         # Define the Dataloader options for the IPU on the training sets
         bz_train = cfg_data["batch_size_training"]
@@ -366,6 +367,7 @@ def load_trainer(
             seed=config["constants"]["seed"],
             model_name=config["constants"]["name"],
             gradient_accumulation=config["trainer"]["trainer"].get("accumulate_grad_batches", None),
+            precision=config["trainer"]["trainer"]["precision"]
         )
 
         from lightning_graphcore import IPUStrategy

--- a/graphium/ipu/ipu_utils.py
+++ b/graphium/ipu/ipu_utils.py
@@ -114,7 +114,7 @@ def load_ipu_options(
         ipu_options.Training.gradientAccumulation(gradient_accumulation)
 
     ipu_options.anchorTensor("input", "input")
-    if precision == 16:
+    if precision == "16-true":
         # IPUOptions.loadFromFile currently doesn't support setting half partials, doing it here
         ipu_options.Precision.setPartialsType(torch.half)
     training_opts = ipu_options


### PR DESCRIPTION
With Lightning 2.0, `precision: 16` means mixed precision (activations are computed in fp16 but weight update is done in fp32). For the IPU we want to train in true 16 precision, which Lightning represents as "16-true".

Also, precision needs to be passed to the function that sets IPUOptions, in order to set half-partials.

I've only corrected the precision in the debug configs. More configs should be fixed.
