### PR TITLE
Finetuning pipeline

### DIFF
--- a/expts/finetune_configs/config_small_gcn.yaml
+++ b/expts/finetune_configs/config_small_gcn.yaml
@@ -1,0 +1,65 @@
+# Testing GCN on ToyMix with FP16/32 on GPU
+constants:
+  name: &name dummy-model
+  config_override: "expts/neurips2023_configs/config_small_gcn.yaml"
+
+accelerator:
+  type: gpu  # cpu or ipu or gpu
+  float32_matmul_precision: medium
+  config_override:
+    datamodule:
+      args:
+        # Data handling-related
+        batch_size_training: 200
+        batch_size_inference: 200
+    predictor:
+      metrics_every_n_steps: 300
+    trainer:
+      trainer:
+        precision: 32
+        accumulate_grad_batches: 1
+
+datamodule:
+  args:
+    task_specific_args:   # To be replaced by a new class "DatasetParams"
+      qm9:
+        df_path: /home/mila/f/frederik.wenkel/scratch/data/graphium/small-dataset/qm9.csv.gz
+        splits_path: /home/mila/f/frederik.wenkel/scratch/data/graphium/small-dataset/qm9_random_splits.pt  # Download with `wget https://storage.googleapis.com/graphium-public/datasets/neurips_2023/Small-dataset/qm9_random_splits.pt`
+        # sample_size: 200 # use sample_size for test
+      tox21:
+        df_path: /home/mila/f/frederik.wenkel/scratch/data/graphium/small-dataset/Tox21-7k-12-labels.csv.gz
+        splits_path: /home/mila/f/frederik.wenkel/scratch/data/graphium/small-dataset/Tox21_random_splits.pt  # Download with `wget https://storage.googleapis.com/graphium-public/datasets/neurips_2023/Small-dataset/Tox21_random_splits.pt`
+        # sample_size: 200 # use sample_size for test
+      zinc:
+        df_path: /home/mila/f/frederik.wenkel/scratch/data/graphium/small-dataset/ZINC12k.csv.gz
+        splits_path: /home/mila/f/frederik.wenkel/scratch/data/graphium/small-dataset/ZINC12k_random_splits.pt  # Download with `wget https://storage.googleapis.com/graphium-public/datasets/neurips_2023/Small-dataset/ZINC12k_random_splits.pt`
+        # sample_size: 200 # use sample_size for test
+    featurization_n_jobs: 4 # 30
+    processed_graph_data_path: "/home/mila/f/frederik.wenkel/scratch/data/graphium/datacache/small-dataset/"
+    num_workers: 4 # 30
+
+architecture:
+  # graph_output_nn:
+  #     graph:
+  #       depth: 1
+  task_heads:
+    tox21:
+      last_activation: none
+
+predictor:
+  loss_fun:
+    tox21: bce_logits_ipu
+
+  torch_scheduler_kwargs:
+    max_num_epochs: &max_epochs 300
+
+trainer:
+  model_checkpoint:
+    dirpath: pretrained_models/
+    filename: dummy-pretrained-model-{epoch}
+    # every_n_epochs: 1
+    save_on_train_epoch_end: true
+  trainer:
+    max_epochs: *max_epochs
+    # check_val_every_n_epoch: 1
+

--- a/expts/finetune_configs/config_toy_finetuning_v1.yaml
+++ b/expts/finetune_configs/config_toy_finetuning_v1.yaml
@@ -1,0 +1,239 @@
+# Testing the gcn model with the PCQMv2 dataset on IPU.
+constants:
+  name: &name finetune_lipophilicity_astrazeneca
+  seed: &seed 42
+  raise_train_error: true   # Whether the code should raise an error if it crashes during training
+
+accelerator:
+  type: gpu  # cpu or ipu or gpu
+  float32_matmul_precision: medium
+  config_override:
+    datamodule:
+      args:
+        # Data handling-related
+        batch_size_training: 200
+        batch_size_inference: 200
+    trainer:
+      trainer:
+        precision: 32
+        accumulate_grad_batches: 1
+
+datamodule:
+  module_type: "ADMETBenchmarkDataModule"
+  args:
+    # TDC specific
+    tdc_benchmark_names: [lipophilicity_astrazeneca]
+    tdc_train_val_seed: *seed
+    # Featurization
+    prepare_dict_or_graph: pyg:graph
+    featurization_n_jobs: 0
+    processed_graph_data_path: "/home/mila/f/frederik.wenkel/scratch/data/graphium/datacache/admet/"
+    featurization_progress: True
+    featurization_backend: "loky"
+    processed_graph_data_path: "../datacache/tdc-admet-demo/"
+    featurization:
+      atom_property_list_onehot: [atomic-number, group, period, total-valence]
+      atom_property_list_float: [degree, formal-charge, radical-electron, aromatic, in-ring]
+      edge_property_list: [bond-type-onehot, stereo, in-ring]
+      add_self_loop: False
+      explicit_H: False # if H is included
+      use_bonds_weights: False
+      pos_encoding_as_features:
+        pos_types:
+          lap_eigvec:
+            pos_level: node
+            pos_type: laplacian_eigvec
+            num_pos: 8
+            normalization: "none" # nomrlization already applied on the eigen vectors
+            disconnected_comp: True # if eigen values/vector for disconnected graph are included
+          lap_eigval:
+            pos_level: node
+            pos_type: laplacian_eigval
+            num_pos: 8
+            normalization: "none" # nomrlization already applied on the eigen vectors
+            disconnected_comp: True # if eigen values/vector for disconnected graph are included
+          rw_pos: # use same name as pe_encoder
+            pos_level: node
+            pos_type: rw_return_probs
+            ksteps: 16
+
+    # cache_data_path: .
+    num_workers: 4 # -1 to use all
+    persistent_workers: False # if use persistent worker at the start of each epoch.
+    # Using persistent_workers false might make the start of each epoch very long.
+    featurization_backend: "loky"
+
+
+architecture:
+  model_type: FullGraphMultiTaskNetwork
+  mup_base_path: null
+  pre_nn:   # Set as null to avoid a pre-nn network
+    out_dim: 64
+    hidden_dims: 256
+    depth: 2
+    activation: relu
+    last_activation: none
+    dropout: &dropout 0.18
+    normalization: &normalization layer_norm
+    last_normalization: *normalization
+    residual_type: none
+
+  pre_nn_edges: null   # Set as null to avoid a pre-nn network
+
+  pe_encoders:
+    out_dim: 32
+    pool: "sum" #"mean" "max"
+    last_norm: None #"batch_norm", "layer_norm"
+    encoders: #la_pos |  rw_pos
+      la_pos:  # Set as null to avoid a pre-nn network
+        encoder_type: "laplacian_pe"
+        input_keys: ["laplacian_eigvec", "laplacian_eigval"]
+        output_keys: ["feat"]
+        hidden_dim: 64
+        out_dim: 32
+        model_type: 'DeepSet' #'Transformer' or 'DeepSet'
+        num_layers: 2
+        num_layers_post: 1 # Num. layers to apply after pooling
+        dropout: 0.1
+        first_normalization: "none" #"batch_norm" or "layer_norm"
+      rw_pos:
+        encoder_type: "mlp"
+        input_keys: ["rw_return_probs"]
+        output_keys: ["feat"]
+        hidden_dim: 64
+        out_dim: 32
+        num_layers: 2
+        dropout: 0.1
+        normalization: "layer_norm" #"batch_norm" or "layer_norm"
+        first_normalization: "layer_norm" #"batch_norm" or "layer_norm"
+
+
+
+  gnn:  # Set as null to avoid a post-nn network
+    in_dim: 64 # or otherwise the correct value
+    out_dim: &gnn_dim 96
+    hidden_dims: *gnn_dim
+    depth: 4
+    activation: gelu
+    last_activation: none
+    dropout: 0.1
+    normalization: "layer_norm"
+    last_normalization: *normalization
+    residual_type: simple
+    virtual_node: 'none'
+    layer_type: 'pyg:gcn' #pyg:gine #'pyg:gps' # pyg:gated-gcn, pyg:gine,pyg:gps
+    layer_kwargs: null # Parameters for the model itself. You could define dropout_attn: 0.1
+
+  graph_output_nn:
+    graph:
+      pooling: [sum]
+      out_dim: *gnn_dim
+      hidden_dims: *gnn_dim
+      depth: 1
+      activation: relu
+      last_activation: none
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+
+  task_heads:
+    lipophilicity_astrazeneca:
+      task_level: graph
+      out_dim: 1
+      hidden_dims: 64
+      depth: 2
+      activation: relu
+      last_activation: none
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+
+#Task-specific
+predictor:
+  metrics_on_progress_bar:
+    lipophilicity_astrazeneca: ["mae"]
+  loss_fun:
+    lipophilicity_astrazeneca: mae
+  random_seed: *seed
+  optim_kwargs:
+    lr: 4.e-5 # warmup can be scheduled using torch_scheduler_kwargs
+    # weight_decay: 1.e-7
+  torch_scheduler_kwargs:
+    module_type: WarmUpLinearLR
+    max_num_epochs: &max_epochs 10
+    warmup_epochs: 2
+    verbose: False
+  scheduler_kwargs:
+  #  monitor: &monitor qm9/mae/train
+  #  mode: min
+  #  frequency: 1
+  target_nan_mask: null # null: no mask, 0: 0 mask, ignore-flatten, ignore-mean-per-label
+  multitask_handling: flatten # flatten, mean-per-label
+
+# Task-specific
+metrics:
+  lipophilicity_astrazeneca:
+    - name: mae
+      metric: mae
+      target_nan_mask: null
+      multitask_handling: flatten
+      threshold_kwargs: null
+    - name: spearman
+      metric: spearmanr
+      threshold_kwargs: null
+      target_nan_mask: null
+      multitask_handling: mean-per-label
+    - name: pearson
+      metric: pearsonr
+      threshold_kwargs: null
+      target_nan_mask: null
+      multitask_handling: mean-per-label
+    - name: r2_score
+      metric: r2
+      target_nan_mask: null
+      multitask_handling: mean-per-label
+      threshold_kwargs: null
+
+trainer:
+  seed: *seed
+  logger:
+    save_dir: logs/finetuned_models/
+    name: *name
+    project: *name
+  #early_stopping:
+  #  monitor: *monitor
+  #  min_delta: 0
+  #  patience: 10
+  #  mode: &mode min
+  finetuning:
+    task: lipophilicity_astrazeneca
+    module: task_heads              # options are (pre_nn,) gnn, graph_output_nn, task_heads
+    choice: zinc                    # choose one from pretrained model (here qm9, tox12 or zinc)
+    depth: 1                        # only modify last FC layer to output dimension (if necessary)
+    
+    added_layers:                   # config of FeedForwardNN
+      out_dim: 1
+      hidden_dims: 16
+      depth: 3
+      activation: relu
+      last_activation: none
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+    
+    epoch_unfreeze_all: none
+
+  model_checkpoint:
+    dirpath: finetuned_models/
+    filename: finetuned-toy-model-{epoch}
+    # monitor: *monitor
+    # mode: *mode
+    # save_top_k: 1
+    save_last: True
+  trainer:
+    max_epochs: *max_epochs
+    min_epochs: 1
+    check_val_every_n_epoch: 2

--- a/expts/finetune_configs/config_toy_finetuning_v2.yaml
+++ b/expts/finetune_configs/config_toy_finetuning_v2.yaml
@@ -1,0 +1,259 @@
+# Testing the gcn model with the PCQMv2 dataset on IPU.
+constants:
+  name: &name finetune_lipophilicity_astrazeneca
+  seed: &seed 42
+  raise_train_error: true   # Whether the code should raise an error if it crashes during training
+
+accelerator:
+  type: gpu  # cpu or ipu or gpu
+  float32_matmul_precision: medium
+  config_override:
+    datamodule:
+      args:
+        # Data handling-related
+        batch_size_training: 200
+        batch_size_inference: 200
+    trainer:
+      trainer:
+        precision: 32
+        accumulate_grad_batches: 1
+
+datamodule:
+  module_type: "ADMETBenchmarkDataModule"
+  args:
+    # TDC specific
+    tdc_benchmark_names: [lipophilicity_astrazeneca]
+    tdc_train_val_seed: *seed
+    # Featurization
+    prepare_dict_or_graph: pyg:graph
+    featurization_n_jobs: 0
+    processed_graph_data_path: "/home/mila/f/frederik.wenkel/scratch/data/graphium/datacache/admet/"
+    featurization_progress: True
+    featurization_backend: "loky"
+    processed_graph_data_path: "../datacache/tdc-admet-demo/"
+    featurization:
+      atom_property_list_onehot: [atomic-number, group, period, total-valence]
+      atom_property_list_float: [degree, formal-charge, radical-electron, aromatic, in-ring]
+      edge_property_list: [bond-type-onehot, stereo, in-ring]
+      add_self_loop: False
+      explicit_H: False # if H is included
+      use_bonds_weights: False
+      pos_encoding_as_features:
+        pos_types:
+          lap_eigvec:
+            pos_level: node
+            pos_type: laplacian_eigvec
+            num_pos: 8
+            normalization: "none" # nomrlization already applied on the eigen vectors
+            disconnected_comp: True # if eigen values/vector for disconnected graph are included
+          lap_eigval:
+            pos_level: node
+            pos_type: laplacian_eigval
+            num_pos: 8
+            normalization: "none" # nomrlization already applied on the eigen vectors
+            disconnected_comp: True # if eigen values/vector for disconnected graph are included
+          rw_pos: # use same name as pe_encoder
+            pos_level: node
+            pos_type: rw_return_probs
+            ksteps: 16
+
+    # cache_data_path: .
+    num_workers: 4 # -1 to use all
+    persistent_workers: False # if use persistent worker at the start of each epoch.
+    # Using persistent_workers false might make the start of each epoch very long.
+    featurization_backend: "loky"
+
+
+architecture:
+  model_type: FullGraphMultiTaskNetwork
+  mup_base_path: null
+  pre_nn:   # Set as null to avoid a pre-nn network
+    out_dim: 64
+    hidden_dims: 256
+    depth: 2
+    activation: relu
+    last_activation: none
+    dropout: &dropout 0.18
+    normalization: &normalization layer_norm
+    last_normalization: *normalization
+    residual_type: none
+
+  pre_nn_edges: null   # Set as null to avoid a pre-nn network
+
+  pe_encoders:
+    out_dim: 32
+    pool: "sum" #"mean" "max"
+    last_norm: None #"batch_norm", "layer_norm"
+    encoders: #la_pos |  rw_pos
+      la_pos:  # Set as null to avoid a pre-nn network
+        encoder_type: "laplacian_pe"
+        input_keys: ["laplacian_eigvec", "laplacian_eigval"]
+        output_keys: ["feat"]
+        hidden_dim: 64
+        out_dim: 32
+        model_type: 'DeepSet' #'Transformer' or 'DeepSet'
+        num_layers: 2
+        num_layers_post: 1 # Num. layers to apply after pooling
+        dropout: 0.1
+        first_normalization: "none" #"batch_norm" or "layer_norm"
+      rw_pos:
+        encoder_type: "mlp"
+        input_keys: ["rw_return_probs"]
+        output_keys: ["feat"]
+        hidden_dim: 64
+        out_dim: 32
+        num_layers: 2
+        dropout: 0.1
+        normalization: "layer_norm" #"batch_norm" or "layer_norm"
+        first_normalization: "layer_norm" #"batch_norm" or "layer_norm"
+
+
+
+  gnn:  # Set as null to avoid a post-nn network
+    in_dim: 64 # or otherwise the correct value
+    out_dim: &gnn_dim 96
+    hidden_dims: *gnn_dim
+    depth: 4
+    activation: gelu
+    last_activation: none
+    dropout: 0.1
+    normalization: "layer_norm"
+    last_normalization: *normalization
+    residual_type: simple
+    virtual_node: 'none'
+    layer_type: 'pyg:gcn' #pyg:gine #'pyg:gps' # pyg:gated-gcn, pyg:gine,pyg:gps
+    layer_kwargs: null # Parameters for the model itself. You could define dropout_attn: 0.1
+
+  graph_output_nn:
+    graph:
+      pooling: [sum]
+      out_dim: *gnn_dim
+      hidden_dims: *gnn_dim
+      depth: 1
+      activation: relu
+      last_activation: none
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+
+  task_heads:
+    qm9:
+      task_level: graph
+      out_dim: 19
+      hidden_dims: 128
+      depth: 2
+      activation: relu
+      last_activation: none
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+    tox21:
+      task_level: graph
+      out_dim: 12
+      hidden_dims: 64
+      depth: 2
+      activation: relu
+      last_activation: sigmoid
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+    zinc:
+      task_level: graph
+      out_dim: 3
+      hidden_dims: 32
+      depth: 2
+      activation: relu
+      last_activation: none
+      dropout: *dropout
+      normalization: *normalization
+      last_normalization: "none"
+      residual_type: none
+
+#Task-specific
+predictor:
+  metrics_on_progress_bar:
+    lipophilicity_astrazeneca: ["mae"]
+  loss_fun:
+    lipophilicity_astrazeneca: mae
+  random_seed: *seed
+  optim_kwargs:
+    lr: 4.e-5 # warmup can be scheduled using torch_scheduler_kwargs
+    # weight_decay: 1.e-7
+  torch_scheduler_kwargs:
+    module_type: WarmUpLinearLR
+    max_num_epochs: &max_epochs 10
+    warmup_epochs: 2
+    verbose: False
+  scheduler_kwargs:
+  #  monitor: &monitor qm9/mae/train
+  #  mode: min
+  #  frequency: 1
+  target_nan_mask: null # null: no mask, 0: 0 mask, ignore-flatten, ignore-mean-per-label
+  multitask_handling: flatten # flatten, mean-per-label
+
+# Task-specific
+metrics:
+  lipophilicity_astrazeneca:
+    - name: mae
+      metric: mae
+      target_nan_mask: null
+      multitask_handling: flatten
+      threshold_kwargs: null
+    - name: spearman
+      metric: spearmanr
+      threshold_kwargs: null
+      target_nan_mask: null
+      multitask_handling: mean-per-label
+    - name: pearson
+      metric: pearsonr
+      threshold_kwargs: null
+      target_nan_mask: null
+      multitask_handling: mean-per-label
+    - name: r2_score
+      metric: r2
+      target_nan_mask: null
+      multitask_handling: mean-per-label
+      threshold_kwargs: null
+
+trainer:
+  seed: *seed
+  logger:
+    save_dir: logs/finetuned_models/
+    name: *name
+    project: *name
+  #early_stopping:
+  #  monitor: *monitor
+  #  min_delta: 0
+  #  patience: 10
+  #  mode: &mode min
+  finetuning:
+    task: lipophilicity_astrazeneca
+    level: graph
+    module: task_heads              # options are (pre_nn, pre_nn_edges) gnn, graph_output_nn, task_heads
+    choice: zinc                    # choose one from pretrained model (here qm9, tox12 or zinc)
+    drop_depth: 1                   # how many layers to drop at the end:
+                                    # must be smaller than pretrained model's depth
+                                    # for TaskHeads:
+                                    #   ==0 only if finetune task has same out_dim
+                                    #   >=1 otherwise, as we need to update out_dim  
+    add_finetune_depth: 0           # if desired, we can also finetune layers before added layers
+    added_layers:                   # here we simply extend the layer, we finetune from
+      out_dim: 1
+      depth: 3
+    
+    epoch_unfreeze_all: none
+
+  model_checkpoint:
+    dirpath: finetuned_models/
+    filename: finetuned-toy-model-{epoch}
+    # monitor: *monitor
+    # mode: *mode
+    # save_top_k: 1
+    save_last: True
+  trainer:
+    max_epochs: *max_epochs
+    min_epochs: 1
+    check_val_every_n_epoch: 2

--- a/expts/main_run_finetuning_v1.py
+++ b/expts/main_run_finetuning_v1.py
@@ -1,0 +1,145 @@
+# General imports
+import argparse
+import os
+from os.path import dirname, abspath
+import yaml
+from copy import deepcopy
+from omegaconf import DictConfig
+import timeit
+from loguru import logger
+from datetime import datetime
+import torch.nn as nn
+from lightning.pytorch.utilities.model_summary import ModelSummary
+
+from graphium.utils.mup import set_base_shapes
+from graphium.finetuning import MolecularFinetuning
+
+# Current project imports
+import graphium
+from graphium.config._loader import (
+    load_datamodule,
+    load_metrics,
+    load_architecture,
+    load_predictor,
+    load_trainer,
+    save_params_to_wandb,
+    load_accelerator,
+    load_yaml_config,
+)
+from graphium.utils.safe_run import SafeRun
+from graphium.utils.command_line_utils import update_config, get_anchors_and_aliases
+
+
+# WandB
+import wandb
+
+# Set up the working directory
+MAIN_DIR = dirname(dirname(abspath(graphium.__file__)))
+
+CONFIG_FILE = "expts/finetune_configs/config_toy_finetuning_v1.yaml"
+
+os.chdir(MAIN_DIR)
+
+
+def main(cfg: dict, run_name: str = "main", add_date_time: bool = True) -> None:
+    st = timeit.default_timer()
+
+    date_time_suffix = ""
+    if add_date_time:
+        date_time_suffix = datetime.now().strftime("%d.%m.%Y_%H.%M.%S")
+
+    wandb.init(entity="multitask-gnn", project=cfg["constants"]["name"], config=cfg)
+
+    # Initialize the accelerator
+    cfg, accelerator_type = load_accelerator(cfg)
+
+    # Load and initialize the dataset
+    datamodule = load_datamodule(cfg, accelerator_type)
+
+    # Initialize the network
+    model_class, model_kwargs = load_architecture(
+        cfg,
+        in_dims=datamodule.in_dims,
+    )
+
+    datamodule.prepare_data()
+
+    metrics = load_metrics(cfg)
+    logger.info(metrics)
+
+    predictor = load_predictor(
+        cfg, model_class, model_kwargs, metrics, accelerator_type, datamodule.task_norms
+    )
+
+
+    ########################
+    # Changes for finetuning
+
+    # Load pretrained & replace in predictor
+    pretrained_model = predictor.load_pretrained_models('dummy-pretrained-model').model     # make pretrained model part of config
+    predictor.model = pretrained_model
+
+    # Adapt pretrained model to new task
+    # We need:
+    #   - task head to finetune from
+    #   - changes to the task head
+
+    predictor.model.modify_architecture(cfg)
+
+    # (Un)freezing will be handled by finetuning callback added to trainer
+
+    predictor.model = set_base_shapes(predictor.model, base=None)       # how do we deal with muP for finetuning; it
+    ########################
+
+
+    logger.info(predictor.model)
+    logger.info(ModelSummary(predictor, max_depth=4))
+
+
+    trainer = load_trainer(cfg, run_name, accelerator_type, date_time_suffix)
+    
+    ########################
+    # Changes for finetuning
+
+    # Add the pl.BaseFinetuning callback to trainer
+    
+    trainer.callbacks.append(
+        MolecularFinetuning(cfg)
+    )
+    ########################
+
+    save_params_to_wandb(trainer.logger, cfg, predictor, datamodule)
+
+    # Determine the max num nodes and edges in training and validation
+    logger.info("About to set the max nodes etc.")
+    predictor.set_max_nodes_edges_per_graph(datamodule, stages=["train", "val"])
+
+    # Run the model training
+    with SafeRun(name="TRAINING", raise_error=cfg["constants"]["raise_train_error"], verbose=True):
+        trainer.fit(model=predictor, datamodule=datamodule)
+
+    # Determine the max num nodes and edges in testing
+    predictor.set_max_nodes_edges_per_graph(datamodule, stages=["test"])
+
+    # Run the model testing
+    with SafeRun(name="TESTING", raise_error=cfg["constants"]["raise_train_error"], verbose=True):
+        trainer.test(model=predictor, datamodule=datamodule)  # , ckpt_path=ckpt_path)
+
+    logger.info("--------------------------------------------")
+    logger.info("total computation used", timeit.default_timer() - st)
+    logger.info("--------------------------------------------")
+    wandb.finish()
+
+    return trainer.callback_metrics
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", help="Path to the config file", default=None)
+
+    args, unknown_args = parser.parse_known_args()
+    if args.config is not None:
+        CONFIG_FILE = args.config
+    cfg = load_yaml_config(CONFIG_FILE, MAIN_DIR, unknown_args)
+
+    main(cfg)

--- a/expts/main_run_finetuning_v2.py
+++ b/expts/main_run_finetuning_v2.py
@@ -1,0 +1,153 @@
+# General imports
+import argparse
+import os
+from os.path import dirname, abspath
+import yaml
+from copy import deepcopy
+from omegaconf import DictConfig
+import timeit
+from loguru import logger
+from datetime import datetime
+import torch.nn as nn
+from lightning.pytorch.utilities.model_summary import ModelSummary
+
+from graphium.utils.mup import set_base_shapes
+from graphium.finetuning import modify_cfg_for_finetuning, MolecularFinetuning
+
+# Current project imports
+import graphium
+from graphium.config._loader import (
+    load_datamodule,
+    load_metrics,
+    load_architecture,
+    load_predictor,
+    load_trainer,
+    save_params_to_wandb,
+    load_accelerator,
+    load_yaml_config,
+)
+from graphium.utils.safe_run import SafeRun
+from graphium.utils.command_line_utils import update_config, get_anchors_and_aliases
+
+
+# WandB
+import wandb
+
+# Set up the working directory
+MAIN_DIR = dirname(dirname(abspath(graphium.__file__)))
+
+CONFIG_FILE = "expts/finetune_configs/config_toy_finetuning_v2.yaml"
+
+os.chdir(MAIN_DIR)
+
+
+def main(cfg: dict, run_name: str = "main", add_date_time: bool = True) -> None:
+    st = timeit.default_timer()
+
+    date_time_suffix = ""
+    if add_date_time:
+        date_time_suffix = datetime.now().strftime("%d.%m.%Y_%H.%M.%S")
+
+
+
+    ########################
+    # Changes for finetuning
+
+    # Modify config
+    cfg = modify_cfg_for_finetuning(cfg)
+
+    ########################
+
+
+    wandb.init(entity="multitask-gnn", project=cfg["constants"]["name"], config=cfg)
+
+    # Initialize the accelerator
+    cfg, accelerator_type = load_accelerator(cfg)
+
+    # Load and initialize the dataset
+    datamodule = load_datamodule(cfg, accelerator_type)
+
+    # Initialize the network
+    model_class, model_kwargs = load_architecture(
+        cfg,
+        in_dims=datamodule.in_dims,
+    )
+
+    datamodule.prepare_data()
+
+    metrics = load_metrics(cfg)
+    logger.info(metrics)
+
+    predictor = load_predictor(
+        cfg, model_class, model_kwargs, metrics, accelerator_type, datamodule.task_norms
+    )
+
+
+    ########################
+    # Changes for finetuning
+
+    # Load pretrained & replace in predictor
+    pretrained_model = predictor.load_pretrained_models('dummy-pretrained-model').model     # make pretrained model part of config
+    
+    # Adapt pretrained model to new task
+    # We need to overwrite shared weights with pretrained
+
+    predictor.model.overwrite_with_pretrained(cfg, pretrained_model)
+
+    # (Un)freezing will be handled by finetuning callback added to trainer
+
+    predictor.model = set_base_shapes(predictor.model, base=None)       # how do we deal with muP for finetuning; it
+    ########################
+
+
+    logger.info(predictor.model)
+    logger.info(ModelSummary(predictor, max_depth=4))
+
+
+    trainer = load_trainer(cfg, run_name, accelerator_type, date_time_suffix)
+    
+    ########################
+    # Changes for finetuning
+
+    # Add the pl.BaseFinetuning callback to trainer
+    
+    trainer.callbacks.append(
+        MolecularFinetuning(cfg)
+    )
+    ########################
+
+    save_params_to_wandb(trainer.logger, cfg, predictor, datamodule)
+
+    # Determine the max num nodes and edges in training and validation
+    logger.info("About to set the max nodes etc.")
+    predictor.set_max_nodes_edges_per_graph(datamodule, stages=["train", "val"])
+
+    # Run the model training
+    with SafeRun(name="TRAINING", raise_error=cfg["constants"]["raise_train_error"], verbose=True):
+        trainer.fit(model=predictor, datamodule=datamodule)
+
+    # Determine the max num nodes and edges in testing
+    predictor.set_max_nodes_edges_per_graph(datamodule, stages=["test"])
+
+    # Run the model testing
+    with SafeRun(name="TESTING", raise_error=cfg["constants"]["raise_train_error"], verbose=True):
+        trainer.test(model=predictor, datamodule=datamodule)  # , ckpt_path=ckpt_path)
+
+    logger.info("--------------------------------------------")
+    logger.info("total computation used", timeit.default_timer() - st)
+    logger.info("--------------------------------------------")
+    wandb.finish()
+
+    return trainer.callback_metrics
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", help="Path to the config file", default=None)
+
+    args, unknown_args = parser.parse_known_args()
+    if args.config is not None:
+        CONFIG_FILE = args.config
+    cfg = load_yaml_config(CONFIG_FILE, MAIN_DIR, unknown_args)
+
+    main(cfg)

--- a/graphium/data/datamodule.py
+++ b/graphium/data/datamodule.py
@@ -1876,19 +1876,23 @@ class MultitaskFromSmilesDataModule(BaseDataModule, IPUDataModuleModifier):
             # Split from an indices file
             file_type = self._get_data_file_type(splits_path)
 
+            train, val, test = split_names
+
             if file_type == "pt":
                 splits = torch.load(splits_path)
+                train_indices = np.asarray(splits[train]).astype("int").tolist()
+                val_indices = np.asarray(splits[val]).astype("int").tolist()
+                test_indices = np.asarray(splits[test]).astype("int").tolist()
             elif file_type in ["csv", "tsv"]:
                 with fsspec.open(str(splits_path)) as f:
                     splits = self._read_csv(splits_path)
+                train_indices = np.asarray(splits[train].dropna()).astype("int").tolist()
+                val_indices = np.asarray(splits[val].dropna()).astype("int").tolist()
+                test_indices = np.asarray(splits[test].dropna()).astype("int").tolist()
             else:
                 raise ValueError(
                     f"file type `{file_type}` for `{splits_path}` not recognised, please use .pt, .csv or .tsv"
                 )
-            train, val, test = split_names
-            train_indices = np.asarray(splits[train].dropna()).astype("int").tolist()
-            val_indices = np.asarray(splits[val].dropna()).astype("int").tolist()
-            test_indices = np.asarray(splits[test].dropna()).astype("int").tolist()
 
         # Filter train, val and test indices
         _, train_idx, _ = np.intersect1d(sample_idx, train_indices, return_indices=True)

--- a/graphium/finetuning/__init__.py
+++ b/graphium/finetuning/__init__.py
@@ -1,0 +1,3 @@
+from .finetuning import MolecularFinetuning
+
+from .utils import modify_cfg_for_finetuning

--- a/graphium/finetuning/finetuning.py
+++ b/graphium/finetuning/finetuning.py
@@ -1,0 +1,56 @@
+from typing import Iterable, List, Dict, Tuple, Union, Callable, Any, Optional, Type
+
+import pytorch_lightning as pl
+
+from torch.optim.optimizer import Optimizer
+from pytorch_lightning.callbacks import BaseFinetuning
+
+
+class MolecularFinetuning(BaseFinetuning):
+    def __init__(
+        self,
+        cfg,
+        train_bn: bool = False
+
+    ):
+        """
+        Finetuning logic
+        """
+        super().__init__()
+
+        cfg_finetune = cfg['trainer']['finetuning']
+        self.depth = cfg_finetune['added_layers']['depth']
+        try:
+            self.depth += cfg_finetune['add_finetune_depth']
+        except:
+            pass
+        self.task = cfg_finetune['task']
+        self.train_bn = train_bn
+        self.epoch_unfreeze_all = cfg_finetune['epoch_unfreeze_all']
+
+    def freeze_before_training(
+        self, pl_module
+    ):
+        # Initially freeze everything
+        self.freeze(modules=pl_module, train_bn=self.train_bn)
+
+    def finetune_function(
+        self,
+        pl_module: pl.LightningModule,
+        epoch: int,
+        optimizer: Optimizer
+    ):
+        # Unfreeze finetuning layers
+        if epoch == 0:       
+            self.unfreeze_and_add_param_group(
+                modules=pl_module.model.task_heads.task_heads[self.task].layers[-self.depth:],
+                optimizer=optimizer,
+                train_bn=self.train_bn
+            )
+
+        if epoch == self.epoch_unfreeze_all:       
+            self.unfreeze_and_add_param_group(
+                modules=pl_module,
+                optimizer=optimizer,
+                train_bn=self.train_bn
+            )

--- a/graphium/finetuning/utils.py
+++ b/graphium/finetuning/utils.py
@@ -1,0 +1,27 @@
+from copy import deepcopy
+
+
+def modify_cfg_for_finetuning(cfg):
+
+    cfg_finetune = cfg['trainer']['finetuning']
+    module = cfg_finetune['module']
+    task = cfg_finetune['task']
+    level = cfg_finetune['level']
+    choice = cfg_finetune['choice']
+    drop_depth = cfg_finetune['drop_depth']
+
+    new_module_kwargs = deepcopy(cfg['architecture'][module][choice])
+
+    upd_kwargs = {
+        'task_level': level,
+        'out_dim': cfg_finetune['added_layers']['out_dim'],
+        'depth': new_module_kwargs['depth'] + cfg_finetune['added_layers']['depth'] - drop_depth
+    }
+
+    new_module_kwargs.update(upd_kwargs)
+
+    cfg['architecture'][module] = {
+        task: new_module_kwargs
+    }
+
+    return cfg

--- a/graphium/nn/architectures/global_architectures.py
+++ b/graphium/nn/architectures/global_architectures.py
@@ -1,6 +1,7 @@
 from typing import Iterable, List, Dict, Tuple, Union, Callable, Any, Optional, Type
 from torch_geometric.data import Batch
 from graphium.ipu.to_dense_batch import to_dense_batch
+from loguru import logger
 
 # Misc imports
 import inspect
@@ -271,6 +272,28 @@ class FeedForwardNN(nn.Module, MupMixin):
 
             if ii < len(residual_out_dims):
                 this_in_dim = residual_out_dims[ii]
+
+    def drop_layers(self, depth: int) -> None:
+        r"""
+        Remove the last layers of the model part.
+        """
+
+        assert depth >= 0
+        assert depth <= len(self.layers)
+
+        if depth > 0:
+            self.layers = self.layers[:-depth]
+
+    def add_layers(self, layers: int) -> None:
+        r"""
+        Add layers to the end of the model.
+        """
+        assert isinstance(layers, nn.ModuleList)
+        assert len(layers) > 0
+        if len(self.layers) > 0:
+            assert layers[0].in_dim == self.layers[-1].out_dim
+
+        self.layers.extend(layers)
 
     def forward(self, h: torch.Tensor) -> torch.Tensor:
         r"""
@@ -1273,6 +1296,95 @@ class FullGraphMultiTaskNetwork(nn.Module, MupMixin):
                     layer.max_num_edges_per_graph = max_edges
 
         self.task_heads.set_max_num_nodes_edges_per_graph(max_nodes, max_edges)
+
+    def modify_architecture(self, cfg):
+
+        cfg_finetune = cfg['trainer']['finetuning']
+        choice = cfg_finetune['choice']
+        task = cfg_finetune['task']
+
+        if cfg_finetune['module'] == 'task_heads':
+            self.task_heads.task_heads = nn.ModuleDict({task: self.task_heads.task_heads[choice]})
+
+            self.task_heads.task_heads[task].drop_layers(cfg_finetune['depth'])
+
+            in_dim = self.task_heads.task_heads[task].layers[-1].out_dim
+            added_layers = FeedForwardNN(in_dim, **cfg_finetune['added_layers']).layers
+
+            self.task_heads.task_heads[task].add_layers(added_layers)
+
+            self.task_heads.task_heads_kwargs = {task: self.task_heads.task_heads_kwargs[choice]}
+            self.task_heads.task_heads_kwargs[task].update(
+                {
+                    'out_dim': cfg_finetune['added_layers']['out_dim'],
+                    'depth': self.task_heads.task_heads_kwargs[task]['depth'] + cfg_finetune['added_layers']['depth'],
+                    'name': 'NN-' + task
+                }
+            )
+
+        else:
+            raise NotImplementedError()
+
+    def overwrite_with_pretrained(self, cfg, pretrained_model):
+
+        cfg_finetune = cfg['trainer']['finetuning']
+        choice = cfg_finetune['choice']
+        task = cfg_finetune['task']
+        added_depth = cfg_finetune['added_layers']['depth']
+
+        for module in ['pre_nn', 'pre_nn_edges', 'gnn', 'graph_output_nn', 'task_heads']:
+
+            if module == cfg_finetune['module']:
+                break
+
+            self.overwrite_complete_module(module, pretrained_model)
+
+        self.overwrite_partial_module(module, task, choice, added_depth, pretrained_model)       
+
+    def overwrite_partial_module(self, module, task, choice, added_depth, pretrained_model):
+        """Completely overwrite the specified module
+        """
+        if module == 'gnn':
+            shared_depth = len(self.task_heads.task_heads[task].layers) - added_depth
+            assert shared_depth >= 0
+            if shared_depth > 0:
+                self.gnn.layers[:shared_depth] = pretrained_model.gnn.layers[:shared_depth]
+
+        if module == "task_heads":
+            shared_depth = len(self.task_heads.task_heads[task].layers) - added_depth
+            assert shared_depth >= 0
+            if shared_depth > 0:
+                self.task_heads.task_heads[task].layers = pretrained_model.task_heads.task_heads[choice].layers[:shared_depth] + self.task_heads.task_heads[task].layers[shared_depth:]
+
+        elif module in ['pre_nn', 'pre_nn_edges']:
+            raise NotImplementedError(f"It is unlikely that we will want to finetune from pre-NNs")
+        
+        else:
+            raise NotImplementedError()
+
+    def overwrite_complete_module(self, module, pretrained_model):
+        """Completely overwrite the specified module
+        """
+        if module == "pre_nn":
+            try:
+                self.pre_nn.layers = pretrained_model.pre_nn.layers
+            except:
+                logger.warning(f"Pretrained ({pretrained_model.pre_nn}) and/or finetune model ({self.pre_nn}) do not use a pre-NN.")
+                pass
+        
+        elif module == "pre_nn_edges":
+            try:
+                self.pre_nn_edges.layers = pretrained_model.pre_nn_edges.layers
+            except:
+                logger.warning(f"Pretrained ({pretrained_model.pre_nn_edges}) and/or finetune model ({self.pre_nn_edges}) do not use a pre-NN-edges.")
+                pass
+        
+        elif module == "gnn":
+            self.gnn.layers = pretrained_model.gnn.layers
+        
+        elif module == "graph_output_nn":
+            for task_level in self.task_heads.graph_output_nn.keys():
+                self.task_heads.graph_output_nn[task_level] = pretrained_model.task_heads.graph_output_nn[task_level]
 
     def __repr__(self) -> str:
         r"""

--- a/graphium/trainer/predictor.py
+++ b/graphium/trainer/predictor.py
@@ -18,7 +18,8 @@ from graphium.data.datamodule import BaseDataModule
 from graphium.utils.moving_average_tracker import MovingAverageTracker
 
 GRAPHIUM_PRETRAINED_MODELS = {
-    "graphium-zinc-micro-dummy-test": "gcs://graphium-public/pretrained-models/graphium-zinc-micro-dummy-test/model.ckpt"
+    "graphium-zinc-micro-dummy-test": "gcs://graphium-public/pretrained-models/graphium-zinc-micro-dummy-test/model.ckpt",
+    "dummy-pretrained-model": "pretrained_models/dummy-pretrained-model.ckpt"  # dummy model (to be deleted later)
 }
 
 


### PR DESCRIPTION
@DomInvivo as discussed a first draft for the Finetuning pipeline.

Two possible pipelines:
`expts/main_run_finetuning_v1.py` (probably to be removed):
- Start with pretrained model
- Remove redundant task heads
- Drop/add layers of model part to be finetuned
- Drawback: Difficult updating of hyperparameters
`expts/main_run_finetuning_v2.py`:
- Initialize new model with final finetuning architecture
- Overwrite parameters that are shared with pretrained model

Main TODOs:
- Use hydra to easy finetuning config
- Create unit test with dummy pretrained model