### PR TITLE
Fixed GatedGCN in float16. Minor cleanups.

### DIFF
--- a/graphium/nn/architectures/global_architectures.py
+++ b/graphium/nn/architectures/global_architectures.py
@@ -1155,11 +1155,7 @@ class FullGraphMultiTaskNetwork(nn.Module, MupMixin):
         # Apply the positional encoders
         g = self.encoder_manager(g)
 
-        g["feat"] = g["feat"]
         e = None
-
-        if "edge_feat" in get_keys(g):
-            g["edge_feat"] = g["edge_feat"]
 
         # Run the pre-processing network on node features
         if self.pre_nn is not None:

--- a/graphium/nn/pyg_layers/gated_gcn_pyg.py
+++ b/graphium/nn/pyg_layers/gated_gcn_pyg.py
@@ -31,7 +31,7 @@ class GatedGCNPyg(MessagePassing, BaseGraphStructure):
         activation: Union[Callable, str] = "relu",
         dropout: float = 0.0,
         normalization: Union[str, Callable] = "none",
-        eps: float = 1e-3,
+        eps: float = 1e-5,
         **kwargs,
     ):
         r"""
@@ -169,15 +169,24 @@ class GatedGCNPyg(MessagePassing, BaseGraphStructure):
         Returns:
             out: dim [n_nodes, out_dim]
         """
-        dim_size = Bx.shape[0]  # or None ??   <--- Double check this
+        dim_size = Bx.shape[0]
 
-        sum_sigma_x = sigma_ij * Bx_j
-        numerator_eta_xj = scatter(sum_sigma_x, index, 0, None, dim_size, reduce="sum")
+        # Sum the messages, weighted by the gates. Sum the gates.
+        numerator_eta_xj = scatter(sigma_ij * Bx_j, index, 0, None, dim_size, reduce="sum")
+        denominator_eta_xj = scatter(sigma_ij, index, 0, None, dim_size, reduce="sum")
 
-        sum_sigma = sigma_ij
-        denominator_eta_xj = scatter(sum_sigma, index, 0, None, dim_size, reduce="sum")
+        # Cast to float32 if needed
+        dtype = denominator_eta_xj.dtype
+        if dtype == torch.float16:
+            numerator_eta_xj = numerator_eta_xj.to(dtype=torch.float32)
+            denominator_eta_xj = denominator_eta_xj.to(dtype=torch.float32)
 
+        # Normalize the messages by the sum of the gates
         out = numerator_eta_xj / (denominator_eta_xj + self.eps)
+
+        # Cast back to float16 if needed
+        if dtype == torch.float16:
+            out = out.to(dtype=dtype)
         return out
 
     def update(self, aggr_out: torch.Tensor, Ax: torch.Tensor):


### PR DESCRIPTION
## Changelogs

- Added an `eps` parameter to the `GatedGCNPyg` layer, with a default value of `1e-3` since `1e-6` was causing numerical issues in float16.
- Removed some useless lines of code from the `FullGraphMultiTaskNetwork.forward`

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [x] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
