### PR TITLE
Gpu mixed-precision overflow fix

### DIFF
--- a/graphium/trainer/predictor.py
+++ b/graphium/trainer/predictor.py
@@ -492,7 +492,7 @@ class PredictorModule(lightning.LightningModule):
         self.task_epoch_summary.update_predictor_state(
             step_name="train",
             targets=outputs["targets"],
-            predictions=outputs["preds"],
+            preds=outputs["preds"],
             loss=outputs["loss"],  # This is the weighted loss for now, but change to task-specific loss
             task_losses=outputs["task_losses"],
             n_epochs=self.current_epoch,
@@ -565,7 +565,7 @@ class PredictorModule(lightning.LightningModule):
 
         self.task_epoch_summary.update_predictor_state(
             step_name=step_name,
-            predictions=preds,
+            preds=preds,
             targets=targets,
             loss=loss,
             task_losses=task_losses,

--- a/graphium/trainer/predictor_summaries.py
+++ b/graphium/trainer/predictor_summaries.py
@@ -239,15 +239,9 @@ class Summary(SummaryInterface):
         targets = self.targets.to(dtype=preds.dtype, device=preds.device)
         # Compute the metrics always used in regression tasks
         metric_logs = {}
-        metric_logs[self.metric_log_name(self.task_name, "mean_pred", self.step_name)] = nan_mean(
-            preds
-        )
-        metric_logs[self.metric_log_name(self.task_name, "std_pred", self.step_name)] = nan_std(
-            preds
-        )
-        metric_logs[self.metric_log_name(self.task_name, "median_pred", self.step_name)] = nan_median(
-            preds
-        )
+        metric_logs[self.metric_log_name(self.task_name, "mean_pred", self.step_name)] = nan_mean(preds)
+        metric_logs[self.metric_log_name(self.task_name, "std_pred", self.step_name)] = nan_std(preds)
+        metric_logs[self.metric_log_name(self.task_name, "median_pred", self.step_name)] = nan_median(preds)
         metric_logs[self.metric_log_name(self.task_name, "mean_target", self.step_name)] = nan_mean(targets)
         metric_logs[self.metric_log_name(self.task_name, "std_target", self.step_name)] = nan_std(targets)
         metric_logs[self.metric_log_name(self.task_name, "median_target", self.step_name)] = nan_median(

--- a/graphium/trainer/predictor_summaries.py
+++ b/graphium/trainer/predictor_summaries.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from graphium.utils.tensor import nan_mean, nan_std, nan_median
+from graphium.utils.tensor import nan_mean, nan_std, nan_median, tensor_fp16_to_fp32
 
 
 class SummaryInterface(object):
@@ -80,7 +80,7 @@ class Summary(SummaryInterface):
         # self.predictor_outputs = None
         self.step_name: str = None
         self.targets: Tensor = None
-        self.predictions: Tensor = None
+        self.preds: Tensor = None
         self.loss = None  # What type?
         self.n_epochs: int = None
 
@@ -88,7 +88,7 @@ class Summary(SummaryInterface):
         self.logged_metrics_exceptions = []  # Track which metric exceptions have been logged
 
     def update_predictor_state(
-        self, step_name: str, targets: Tensor, predictions: Tensor, loss: Tensor, n_epochs: int
+        self, step_name: str, targets: Tensor, preds: Tensor, loss: Tensor, n_epochs: int
     ):
         r"""
         update the state of the predictor
@@ -101,7 +101,7 @@ class Summary(SummaryInterface):
         """
         self.step_name = step_name
         self.targets = targets
-        self.predictions = predictions
+        self.preds = preds
         self.loss = loss
         self.n_epochs = n_epochs
 
@@ -120,7 +120,7 @@ class Summary(SummaryInterface):
         metrics[self.metric_log_name(self.task_name, "loss", self.step_name)] = self.loss
         self.summaries[self.step_name] = Summary.Results(
             targets=self.targets,
-            predictions=self.predictions,
+            preds=self.preds,
             loss=self.loss,
             metrics=metrics,  # Should include task name from get_metrics_logs()
             monitored_metric=f"{self.monitor}/{self.step_name}",  # Include task name?
@@ -232,17 +232,21 @@ class Summary(SummaryInterface):
         Returns:
             A dictionary of metrics to log.
         """
-        targets = self.targets.to(dtype=self.predictions.dtype, device=self.predictions.device)
+
+        targets = tensor_fp16_to_fp32(targets)
+        preds = tensor_fp16_to_fp32(preds)
+
+        targets = self.targets.to(dtype=preds.dtype, device=preds.device)
         # Compute the metrics always used in regression tasks
         metric_logs = {}
         metric_logs[self.metric_log_name(self.task_name, "mean_pred", self.step_name)] = nan_mean(
-            self.predictions
+            preds
         )
         metric_logs[self.metric_log_name(self.task_name, "std_pred", self.step_name)] = nan_std(
-            self.predictions
+            preds
         )
         metric_logs[self.metric_log_name(self.task_name, "median_pred", self.step_name)] = nan_median(
-            self.predictions
+            preds
         )
         metric_logs[self.metric_log_name(self.task_name, "mean_target", self.step_name)] = nan_mean(targets)
         metric_logs[self.metric_log_name(self.task_name, "std_target", self.step_name)] = nan_std(targets)
@@ -264,7 +268,7 @@ class Summary(SummaryInterface):
                 self.task_name, key, self.step_name
             )  # f"{key}/{self.step_name}"
             try:
-                metric_logs[metric_name] = metric(self.predictions, targets)
+                metric_logs[metric_name] = metric(preds, targets)
             except Exception as e:
                 metric_logs[metric_name] = torch.as_tensor(float("nan"))
                 # Warn only if it's the first warning for that metric
@@ -292,7 +296,7 @@ class Summary(SummaryInterface):
         def __init__(
             self,
             targets: Tensor = None,
-            predictions: Tensor = None,
+            preds: Tensor = None,
             loss: float = None,  # Is this supposed to be a Tensor or float?
             metrics: dict = None,
             monitored_metric: str = None,
@@ -302,14 +306,14 @@ class Summary(SummaryInterface):
             This inner class is used as a container for storing the results of the summary.
             Parameters:
                 targets: the targets
-                predictions: the prediction tensor
+                preds: the prediction tensor
                 loss: the loss, float or tensor
                 metrics: the metrics
                 monitored_metric: the monitored metric
                 n_epochs: the number of epochs
             """
             self.targets = targets.detach().cpu()
-            self.predictions = predictions.detach().cpu()
+            self.preds = preds.detach().cpu()
             self.loss = loss.item() if isinstance(loss, Tensor) else loss
             self.monitored_metric = monitored_metric
             if monitored_metric in metrics.keys():
@@ -371,7 +375,7 @@ class TaskSummaries(SummaryInterface):
         self,
         step_name: str,
         targets: Dict[str, Tensor],
-        predictions: Dict[str, Tensor],
+        preds: Dict[str, Tensor],
         loss: Tensor,
         task_losses: Dict[str, Tensor],
         n_epochs: int,
@@ -381,7 +385,7 @@ class TaskSummaries(SummaryInterface):
         Parameters:
             step_name: the name of the step
             targets: the target tensors
-            predictions: the prediction tensors
+            preds: the prediction tensors
             loss: the loss tensor
             task_losses: the task losses
             n_epochs: the number of epochs
@@ -392,7 +396,7 @@ class TaskSummaries(SummaryInterface):
             self.task_summaries[task].update_predictor_state(
                 step_name,
                 targets[task],
-                predictions[task].detach(),
+                preds[task].detach(),
                 task_losses[task].detach(),
                 n_epochs,
             )

--- a/graphium/trainer/predictor_summaries.py
+++ b/graphium/trainer/predictor_summaries.py
@@ -233,10 +233,11 @@ class Summary(SummaryInterface):
             A dictionary of metrics to log.
         """
 
-        targets = tensor_fp16_to_fp32(targets)
-        preds = tensor_fp16_to_fp32(preds)
+        targets = tensor_fp16_to_fp32(self.targets)
+        preds = tensor_fp16_to_fp32(self.preds)
 
-        targets = self.targets.to(dtype=preds.dtype, device=preds.device)
+        targets = targets.to(dtype=preds.dtype, device=preds.device)
+
         # Compute the metrics always used in regression tasks
         metric_logs = {}
         metric_logs[self.metric_log_name(self.task_name, "mean_pred", self.step_name)] = nan_mean(preds)

--- a/graphium/utils/tensor.py
+++ b/graphium/utils/tensor.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
-from typing import Iterable, List, Union, Any, Callable
+from typing import Iterable, List, Union, Any, Callable, Dict
 from inspect import getfullargspec
 from copy import copy, deepcopy
 from loguru import logger
@@ -384,3 +384,33 @@ def arg_in_func(fn, arg):
     """
     fn_args = getfullargspec(fn)
     return (fn_args.varkw is not None) or (arg in fn_args[0])
+
+def tensor_fp16_to_fp32(tensor: Tensor) -> Tensor:
+    r"""Cast a tensor from fp16 to fp32 if it is in fp16
+
+    Parameters:
+        tensor: A tensor. If it is in fp16, it will be casted to fp32
+
+    Returns:
+        tensor: The tensor casted to fp32 if it was in fp16
+    """
+    if tensor.dtype == torch.float16:
+        return tensor.to(dtype=torch.float32)
+    return tensor
+
+def dict_tensor_fp16_to_fp32(dict_tensor: Union[Tensor, Dict[str, Tensor], Dict[str, Dict[str, Tensor]]]) -> Union[Tensor, Dict[str, Tensor], Dict[str, Dict[str, Tensor]]]:
+    r"""Recursively Cast a dictionary of tensors from fp16 to fp32 if it is in fp16
+
+    Parameters:
+        dict_tensor: A recursive dictionary of tensors. To be casted to fp32 if it was in fp16.
+
+    Returns:
+        dict_tensor: The recursive dictionary of tensors casted to fp32 if it was in fp16
+    """
+    if isinstance(dict_tensor, dict):
+        for key, value in dict_tensor.items():
+            dict_tensor[key] = dict_tensor_fp16_to_fp32(value)
+    else:
+        dict_tensor = tensor_fp16_to_fp32(dict_tensor)
+
+    return dict_tensor

--- a/graphium/utils/tensor.py
+++ b/graphium/utils/tensor.py
@@ -385,6 +385,7 @@ def arg_in_func(fn, arg):
     fn_args = getfullargspec(fn)
     return (fn_args.varkw is not None) or (arg in fn_args[0])
 
+
 def tensor_fp16_to_fp32(tensor: Tensor) -> Tensor:
     r"""Cast a tensor from fp16 to fp32 if it is in fp16
 
@@ -398,7 +399,10 @@ def tensor_fp16_to_fp32(tensor: Tensor) -> Tensor:
         return tensor.to(dtype=torch.float32)
     return tensor
 
-def dict_tensor_fp16_to_fp32(dict_tensor: Union[Tensor, Dict[str, Tensor], Dict[str, Dict[str, Tensor]]]) -> Union[Tensor, Dict[str, Tensor], Dict[str, Dict[str, Tensor]]]:
+
+def dict_tensor_fp16_to_fp32(
+    dict_tensor: Union[Tensor, Dict[str, Tensor], Dict[str, Dict[str, Tensor]]]
+) -> Union[Tensor, Dict[str, Tensor], Dict[str, Dict[str, Tensor]]]:
     r"""Recursively Cast a dictionary of tensors from fp16 to fp32 if it is in fp16
 
     Parameters:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,13 @@
 Unit tests for the metrics and wrappers of graphium/utils/...
 """
 
+import torch
+import numpy as np
+import scipy as sp
+import unittest as ut
+import gzip
+
+from graphium.utils.read_file import file_opener
 from graphium.utils.tensor import (
     nan_mad,
     nan_mean,
@@ -12,12 +19,6 @@ from graphium.utils.tensor import (
     tensor_fp16_to_fp32,
 )
 from graphium.utils.safe_run import SafeRun
-import torch
-import numpy as np
-import scipy as sp
-import unittest as ut
-import gzip
-from graphium.utils.read_file import file_opener
 
 
 class test_nan_statistics(ut.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,15 @@
 Unit tests for the metrics and wrappers of graphium/utils/...
 """
 
-from graphium.utils.tensor import nan_mad, nan_mean, nan_std, nan_var, nan_median, dict_tensor_fp16_to_fp32, tensor_fp16_to_fp32
+from graphium.utils.tensor import (
+    nan_mad,
+    nan_mean,
+    nan_std,
+    nan_var,
+    nan_median,
+    dict_tensor_fp16_to_fp32,
+    tensor_fp16_to_fp32,
+)
 from graphium.utils.safe_run import SafeRun
 import torch
 import numpy as np
@@ -183,7 +191,6 @@ class test_SafeRun(ut.TestCase):
 
 
 class TestTensorFp16ToFp32(ut.TestCase):
-
     def test_tensor_fp16_to_fp32(self):
         # Create a tensor
         tensor = torch.randn(10, 10).half()
@@ -202,7 +209,6 @@ class TestTensorFp16ToFp32(ut.TestCase):
         tensor_fp32 = tensor_fp16_to_fp32(tensor)
         self.assertFalse(tensor_fp32.dtype == torch.float32)
 
-
     def test_dict_tensor_fp16_to_fp32(self):
         # Create a dictionary of tensors
         tensor_dict = {
@@ -219,7 +225,7 @@ class TestTensorFp16ToFp32(ut.TestCase):
                 "h3": torch.randn(10, 10).float(),
                 "h4": torch.randn(10, 10).half(),
                 "h5": torch.randn(10, 10).int(),
-            }
+            },
         }
 
         # Convert the dictionary to fp32


### PR DESCRIPTION
## Changelogs

- Casting the tensors to float32 before computing the metrics. This prevents overflowing when there are a lot of samples.
- Changed `predictions` to `preds`
- Added functions `tensor_fp16_to_fp32` and `dict_tensor_fp16_to_fp32` with their unit-tests

---

_Checklist:_

- [x] _Was this PR discussed in an issue?_ Yes, discussed in issue #406 
- [x] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [x] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

@luis-mueller can you double-check that the metrics now work without overflow?
