### PR TITLE
Fix `strategy` argument for trainer

### DIFF
--- a/graphium/config/_loader.py
+++ b/graphium/config/_loader.py
@@ -371,7 +371,7 @@ def load_trainer(
     cfg_trainer = deepcopy(config["trainer"])
 
     # Define the IPU plugin if required
-    strategy = config["trainer"]["trainer"].get("strategy", "auto")
+    strategy = cfg_trainer["trainer"].pop("strategy", "auto")
     if accelerator_type == "ipu":
         ipu_opts, ipu_inference_opts = _get_ipu_opts(config)
 


### PR DESCRIPTION
## Changelogs

- Fix `trainer.trainer.strategy`. Previously the argument was passed twice for `Trainer` construction and thus error.

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
