### PR TITLE
Node inconsistent hydrogens number

### DIFF
--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -40,14 +40,12 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
     def merge_columns(data: pd.Series):
         data_name = data.name
         data = data.to_list()
-        missing_label_idx = [i for i, d in enumerate(data) if not isinstance(d, np.ndarray) and math.isnan(d)]
-        data = [np.array([np.nan]) if i in missing_label_idx else d for i, d in enumerate(data)]
-
+        data = [np.array([np.nan]) if not isinstance(d, np.ndarray) and math.isnan(d) else d for d in data]
         # Ensure that all shapes are either the same, or 1
         sizes = [d.shape[0] for d in data]
         maxsize = max(sizes)
         for i, size in enumerate(sizes):
-            if i in missing_label_idx:
+            if size == 1 and np.isnan(data[i]).all():
                 continue
             if size != maxsize:
                 raise ValueError(

--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -38,6 +38,7 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
         return data.apply(unpack)
 
     def merge_columns(data: pd.Series):
+        data_name = data.name
         data = data.to_list()
         missing_label_idx = [i for i, d in enumerate(data) if not isinstance(d, np.ndarray) and math.isnan(d)]
         data = [np.array([np.nan]) if i in missing_label_idx else d for i, d in enumerate(data)]
@@ -50,7 +51,7 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
                 continue
             if size != maxsize:
                 raise ValueError(
-                    f"Size mismatch between columns in {task_level} columns {data.name} sizes: {sizes}"
+                    f"Size mismatch between columns in {task_level} columns {data_name} sizes: {sizes}"
                 )
 
         # Pad all arrays to the same size

--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -45,8 +45,10 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
         # Ensure that all shapes are either the same, or 1
         sizes = [d.shape[0] for d in data]
         maxsize = max(sizes)
-        for size in sizes:
-            if (size != maxsize) and (size != 1):
+        for i, size in enumerate(sizes):
+            if i in missing_label_idx:
+                continue
+            if (size != maxsize):
                 raise ValueError(
                     f"Size mismatch between columns in {task_level} columns {data.name} sizes: {sizes}"
                 )

--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -7,7 +7,8 @@ import math
 
 
 def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
-    """Extracts labels in label_cols from dataframe df for a given task_level.
+    """
+    Extracts labels in label_cols from dataframe df for a given task_level.
     Returns a list of numpy arrays converted to the correct shape. Multiple
     targets are concatenated for each graph.
     """
@@ -39,6 +40,17 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
     def merge_columns(data: pd.Series):
         data = data.to_list()
         data = [np.array([np.nan]) if not isinstance(d, np.ndarray) and math.isnan(d) else d for d in data]
+
+        # Ensure that all shapes are either the same, or 1
+        sizes = [d.shape[0] for d in data]
+        maxsize = max(sizes)
+        for size in sizes:
+            if (size != maxsize) and (size != 1):
+                raise ValueError(
+                    f"Size mismatch between columns in {task_level} columns {data.name} sizes: {sizes}"
+                )
+
+        # Pad all arrays to the same size
         padded_data = itertools.zip_longest(*data, fillvalue=np.nan)
         data = np.stack(list(padded_data), 1).T
         return data

--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -48,7 +48,7 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
         for i, size in enumerate(sizes):
             if i in missing_label_idx:
                 continue
-            if (size != maxsize):
+            if size != maxsize:
                 raise ValueError(
                     f"Size mismatch between columns in {task_level} columns {data.name} sizes: {sizes}"
                 )

--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -39,7 +39,8 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
 
     def merge_columns(data: pd.Series):
         data = data.to_list()
-        data = [np.array([np.nan]) if not isinstance(d, np.ndarray) and math.isnan(d) else d for d in data]
+        missing_label_idx = [i for i, d in enumerate(data) if not isinstance(d, np.ndarray) and math.isnan(d)]
+        data = [np.array([np.nan]) if i in missing_label_idx else d for i, d in enumerate(data)]
 
         # Ensure that all shapes are either the same, or 1
         sizes = [d.shape[0] for d in data]

--- a/graphium/data/utils.py
+++ b/graphium/data/utils.py
@@ -130,7 +130,7 @@ def found_size_mismatch(task: str, features: Union[Data, GraphDict], labels: np.
 
     mismatch = False
 
-    if np.isnan(labels).any():
+    if np.isnan(labels).all():
         pass
 
     elif task.startswith("graph_"):

--- a/tests/test_multitask_datamodule.py
+++ b/tests/test_multitask_datamodule.py
@@ -330,11 +330,6 @@ class Test_Multitask_DataModule(ut.TestCase):
                 for missing_col in label_cols[:replace]:
                     df.loc[drop_index, missing_col] = None
 
-                if replace == 1:
-                    with self.assertRaises(ValueError):
-                        graphium.data.datamodule.extract_labels(df, level, label_cols)
-                    continue
-
                 msg = f"level={level}, replace={replace}"
 
                 output = graphium.data.datamodule.extract_labels(df, level, label_cols)

--- a/tests/test_multitask_datamodule.py
+++ b/tests/test_multitask_datamodule.py
@@ -330,16 +330,18 @@ class Test_Multitask_DataModule(ut.TestCase):
                 for missing_col in label_cols[:replace]:
                     df.loc[drop_index, missing_col] = None
 
+                msg = f"level={level}, replace={replace}"
+
                 output = graphium.data.datamodule.extract_labels(df, level, label_cols)
 
                 for idx in drop_index:
-                    assert len(output[idx].shape) == 2
-                    assert output[idx].shape[1] == len(label_cols)
+                    self.assertEqual(len(output[idx].shape), 2, msg=msg)
+                    self.assertEqual(output[idx].shape[1], len(label_cols), msg=msg)
 
                     # Check that number of labels is adjusted correctly
                     if replace == 1:
                         non_missing_col = label_cols[1]
-                        assert output[idx].shape[0] == len(df[non_missing_col][idx])
+                        self.assertEqual(output[idx].shape[0], len(df[non_missing_col][idx]), msg=msg)
 
     def test_tdc_admet_benchmark_data_module(self):
         """

--- a/tests/test_multitask_datamodule.py
+++ b/tests/test_multitask_datamodule.py
@@ -330,6 +330,11 @@ class Test_Multitask_DataModule(ut.TestCase):
                 for missing_col in label_cols[:replace]:
                     df.loc[drop_index, missing_col] = None
 
+                if replace == 1:
+                    with self.assertRaises(ValueError):
+                        graphium.data.datamodule.extract_labels(df, level, label_cols)
+                    continue
+
                 msg = f"level={level}, replace={replace}"
 
                 output = graphium.data.datamodule.extract_labels(df, level, label_cols)


### PR DESCRIPTION
## Changelogs

- The previous code was allowing inconsistent number of labels per molecule to go through, leading to errors if there are mistakes in the dataset or the choice of `label_cols`. For instance, if we have the cols `node_feat1` of size 10, and `node_feat2` of size 12, but they're both for the same molecule, then the code should either crash, or filter out the inconsistencies.

@engmubarak48 and @luis-mueller , I'm not sure I understand all the logic implemented for the padding, so I'd like your opinion on this PR.

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
