### PR TITLE
Fixed the CLI command definition and data module preparation

### DIFF
--- a/graphium/trainer/predictor.py
+++ b/graphium/trainer/predictor.py
@@ -699,8 +699,7 @@ class PredictorModule(lightning.LightningModule):
         return PredictorModule.load_from_checkpoint(name_or_path, map_location=device)
 
     def set_max_nodes_edges_per_graph(self, datamodule: BaseDataModule, stages: Optional[List[str]] = None):
-        for stage in stages:
-            datamodule.setup(stage)
+        datamodule.setup()
 
         max_nodes = datamodule.get_max_num_nodes_datamodule(stages)
         max_edges = datamodule.get_max_num_edges_datamodule(stages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 
 [project.scripts]
 graphium = "graphium.cli.main:app"
-graphium-train = "graphium.cli.train_finetune:cli"
+graphium-train = "graphium.cli.train_finetune_test:cli"
 
 [project.urls]
 Website = "https://graphium.datamol.io/"


### PR DESCRIPTION
## Changelogs

- Properly define the `graphium-train` CLI command in the `pyproject.toml`. 
- Revert the changes on calling the `setup()` only for relevant changes. 
