### PR TITLE
Fix distributed training artifact and metrics logging

### DIFF
--- a/graphium/trainer/predictor.py
+++ b/graphium/trainer/predictor.py
@@ -600,7 +600,7 @@ class PredictorModule(lightning.LightningModule):
         else:
             epoch_time = time.time() - self.epoch_start_time
             self.epoch_start_time = None
-            self.log("epoch_time", torch.tensor(epoch_time))
+            self.log("epoch_time", torch.tensor(epoch_time), sync_dist=True)
 
     def on_validation_epoch_start(self) -> None:
         self.mean_val_time_tracker.reset()
@@ -629,7 +629,7 @@ class PredictorModule(lightning.LightningModule):
         concatenated_metrics_logs = self.task_epoch_summary.concatenate_metrics_logs(metrics_logs)
         concatenated_metrics_logs["val/mean_time"] = torch.tensor(self.mean_val_time_tracker.mean_value)
         concatenated_metrics_logs["val/mean_tput"] = self.mean_val_tput_tracker.mean_value
-        self.log_dict(concatenated_metrics_logs)
+        self.log_dict(concatenated_metrics_logs, sync_dist=True)
 
         # Save yaml file with the per-task metrics summaries
         full_dict = {}
@@ -643,7 +643,7 @@ class PredictorModule(lightning.LightningModule):
         self.test_step_outputs.clear()
         concatenated_metrics_logs = self.task_epoch_summary.concatenate_metrics_logs(metrics_logs)
 
-        self.log_dict(concatenated_metrics_logs)
+        self.log_dict(concatenated_metrics_logs, sync_dist=True)
 
         # Save yaml file with the per-task metrics summaries
         full_dict = {}


### PR DESCRIPTION
## Changelogs

- Fix wandb support when using distributed training (`torchrun`)
- sync metrics across distributed training processes.

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [x] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
