### PR TITLE
Fix mup for the layers with AttentionLayerMup

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -17,7 +17,6 @@ dependencies:
   - pandas >=1.0
   - scikit-learn
   - fastparquet
-  - networkx
 
   # viz
   - matplotlib >=3.0.1

--- a/env.yml
+++ b/env.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  # - pyg # Add for Windows
+  - pyg # Add for Windows
 
 dependencies:
   - python >=3.8
@@ -17,6 +17,7 @@ dependencies:
   - pandas >=1.0
   - scikit-learn
   - fastparquet
+  - networkx
 
   # viz
   - matplotlib >=3.0.1
@@ -28,17 +29,17 @@ dependencies:
   - gcsfs >=2021.6
 
   # ML packages
-  - cuda-version # works also with CPU-only system.
+  # - cuda-version # works also with CPU-only system.
   - pytorch >=1.12
   - lightning >=2.0
   - torchmetrics >=0.7.0,<0.11
   - ogb
-  - pytorch_geometric >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`
+  - pyg >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`
   - wandb
   - mup
-  - pytorch_sparse >=0.6
-  - pytorch_cluster >=1.5
-  - pytorch_scatter >=2.0
+  - pytorch-sparse >=0.6
+  - pytorch-cluster >=1.5
+  - pytorch-scatter >=2.0
 
   # chemistry
   - rdkit

--- a/env.yml
+++ b/env.yml
@@ -31,7 +31,7 @@ dependencies:
   # ML packages
   - cuda-version # works also with CPU-only system.
   - pytorch >=1.12
-  - lightning >=2.0
+  - lightning >=2.0,<2.1.1
   - torchmetrics >=0.7.0,<0.11
   - ogb
   - pytorch_geometric >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`

--- a/env.yml
+++ b/env.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  - pyg # Add for Windows
+  # - pyg # Add for Windows
 
 dependencies:
   - python >=3.8
@@ -34,7 +34,7 @@ dependencies:
   - lightning >=2.0
   - torchmetrics >=0.7.0,<0.11
   - ogb
-  - pyg >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`
+  - pytorch_geometric >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`
   - wandb
   - mup
   - pytorch-sparse >=0.6

--- a/env.yml
+++ b/env.yml
@@ -29,7 +29,7 @@ dependencies:
   - gcsfs >=2021.6
 
   # ML packages
-  # - cuda-version # works also with CPU-only system.
+  - cuda-version # works also with CPU-only system.
   - pytorch >=1.12
   - lightning >=2.0
   - torchmetrics >=0.7.0,<0.11
@@ -37,9 +37,9 @@ dependencies:
   - pytorch_geometric >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`
   - wandb
   - mup
-  - pytorch-sparse >=0.6
-  - pytorch-cluster >=1.5
-  - pytorch-scatter >=2.0
+  - pytorch_sparse >=0.6
+  - pytorch_cluster >=1.5
+  - pytorch_scatter >=2.0
 
   # chemistry
   - rdkit

--- a/env.yml
+++ b/env.yml
@@ -31,7 +31,7 @@ dependencies:
   # ML packages
   - cuda-version # works also with CPU-only system.
   - pytorch >=1.12
-  - lightning >=2.0,<2.1.1
+  - lightning >=2.0
   - torchmetrics >=0.7.0,<0.11
   - ogb
   - pytorch_geometric >=2.0 # Use `pyg` for Windows instead of `pytorch_geometric`

--- a/graphium/nn/architectures/global_architectures.py
+++ b/graphium/nn/architectures/global_architectures.py
@@ -1324,6 +1324,10 @@ class FeedForwardGraph(FeedForwardNN):
                     _recursive_divide_dim(v)
                 elif k in ["in_dim", "out_dim", "in_dim_edges", "out_dim_edges"]:
                     x[k] = round(v / divide_factor)
+                elif k in ["embed_dim"]:
+                    num_heads = x.get("num_heads", 1)
+                    x[k] = round(v / divide_factor)
+                    assert x[k] % num_heads == 0, f"embed_dim={x[k]} is not divisible by num_heads={num_heads}"
 
         _recursive_divide_dim(kwargs["layer_kwargs"])
 

--- a/graphium/nn/architectures/global_architectures.py
+++ b/graphium/nn/architectures/global_architectures.py
@@ -1327,7 +1327,9 @@ class FeedForwardGraph(FeedForwardNN):
                 elif k in ["embed_dim"]:
                     num_heads = x.get("num_heads", 1)
                     x[k] = round(v / divide_factor)
-                    assert x[k] % num_heads == 0, f"embed_dim={x[k]} is not divisible by num_heads={num_heads}"
+                    assert (
+                        x[k] % num_heads == 0
+                    ), f"embed_dim={x[k]} is not divisible by num_heads={num_heads}"
 
         _recursive_divide_dim(kwargs["layer_kwargs"])
 

--- a/graphium/nn/pyg_layers/gps_pyg.py
+++ b/graphium/nn/pyg_layers/gps_pyg.py
@@ -339,7 +339,7 @@ class GPSLayerPyg(BaseGraphModule):
         attn_kwargs.setdefault("embed_dim", self.in_dim)
         if force_consistent_in_dim:
             embed_dim = attn_kwargs["embed_dim"]
-            # assert embed_dim == self.in_dim, f"embed_dim={embed_dim} must be equal to in_dim={self.in_dim}"
+            assert embed_dim == self.in_dim, f"embed_dim={embed_dim} must be equal to in_dim={self.in_dim}"
 
         # Initialize the Attention layer
         attn_layer, attn_class = None, None

--- a/graphium/nn/pyg_layers/gps_pyg.py
+++ b/graphium/nn/pyg_layers/gps_pyg.py
@@ -194,7 +194,9 @@ class GPSLayerPyg(BaseGraphModule):
         self.biased_attention_key = biased_attention_key
         # Initialize the MPNN and Attention layers
         self.mpnn = self._parse_mpnn_layer(mpnn_type, mpnn_kwargs)
-        self.attn_layer = self._parse_attn_layer(attn_type, self.biased_attention_key, attn_kwargs, force_consistent_in_dim=force_consistent_in_dim)
+        self.attn_layer = self._parse_attn_layer(
+            attn_type, self.biased_attention_key, attn_kwargs, force_consistent_in_dim=force_consistent_in_dim
+        )
 
         self.output_scale = output_scale
         self.use_edges = True if self.in_dim_edges is not None else False
@@ -307,7 +309,11 @@ class GPSLayerPyg(BaseGraphModule):
         return mpnn_layer
 
     def _parse_attn_layer(
-        self, attn_type, biased_attention_key: str, attn_kwargs: Dict[str, Any], force_consistent_in_dim: bool = True
+        self,
+        attn_type,
+        biased_attention_key: str,
+        attn_kwargs: Dict[str, Any],
+        force_consistent_in_dim: bool = True,
     ) -> Optional[Module]:
         """
         parse the input attention layer and check if it is valid

--- a/graphium/nn/pyg_layers/gps_pyg.py
+++ b/graphium/nn/pyg_layers/gps_pyg.py
@@ -54,6 +54,7 @@ class GPSLayerPyg(BaseGraphModule):
         precision: str = "32",
         biased_attention_key: Optional[str] = None,
         attn_kwargs=None,
+        force_consistent_in_dim: bool = True,
         droppath_rate_attn: float = 0.0,
         droppath_rate_ffn: float = 0.0,
         hidden_dim_scaling: float = 4.0,
@@ -78,12 +79,6 @@ class GPSLayerPyg(BaseGraphModule):
 
             out_dim:
                 Output node feature dimensions of the layer
-
-            in_dim:
-                Input edge feature dimensions of the layer
-
-            out_dim:
-                Output edge feature dimensions of the layer
 
             in_dim_edges:
                 input edge-feature dimensions of the layer
@@ -119,6 +114,11 @@ class GPSLayerPyg(BaseGraphModule):
 
             attn_kwargs:
                 kwargs for attention layer
+
+            force_consistent_in_dim:
+                whether to force the `embed_dim` to be the same as the `in_dim` for the attention and mpnn.
+                The argument is only valid if `attn_type` is not None. If `embed_dim` is not provided,
+                it will be set to `in_dim` by default, so this parameter won't have an effect.
 
             droppath_rate_attn:
                 stochastic depth drop rate for attention layer https://arxiv.org/abs/1603.09382
@@ -194,7 +194,7 @@ class GPSLayerPyg(BaseGraphModule):
         self.biased_attention_key = biased_attention_key
         # Initialize the MPNN and Attention layers
         self.mpnn = self._parse_mpnn_layer(mpnn_type, mpnn_kwargs)
-        self.attn_layer = self._parse_attn_layer(attn_type, self.biased_attention_key, attn_kwargs)
+        self.attn_layer = self._parse_attn_layer(attn_type, self.biased_attention_key, attn_kwargs, force_consistent_in_dim=force_consistent_in_dim)
 
         self.output_scale = output_scale
         self.use_edges = True if self.in_dim_edges is not None else False
@@ -237,8 +237,6 @@ class GPSLayerPyg(BaseGraphModule):
         """
         # pe, feat, edge_index, edge_feat = batch.pos_enc_feats_sign_flip, batch.feat, batch.edge_index, batch.edge_feat
         feat = batch.feat
-        if self.use_edges:
-            edges_feat_in = batch.edge_feat
 
         feat_in = feat  # for first residual connection
 
@@ -309,13 +307,16 @@ class GPSLayerPyg(BaseGraphModule):
         return mpnn_layer
 
     def _parse_attn_layer(
-        self, attn_type, biased_attention_key: str, attn_kwargs: Dict[str, Any]
+        self, attn_type, biased_attention_key: str, attn_kwargs: Dict[str, Any], force_consistent_in_dim: bool = True
     ) -> Optional[Module]:
         """
         parse the input attention layer and check if it is valid
         Parameters:
             attn_type: type of the attention layer
             biased_attention_key: key for the attenion bias
+            attn_kwargs: kwargs for the attention layer
+            force_consistent_in_dim: whether to force the `embed_dim` to be the same as the `in_dim`
+
         Returns:
             attn_layer: the attention layer
         """
@@ -323,11 +324,16 @@ class GPSLayerPyg(BaseGraphModule):
         # Set the default values for the Attention layer
         if attn_kwargs is None:
             attn_kwargs = {}
-        attn_kwargs.setdefault("embed_dim", self.in_dim)
         attn_kwargs.setdefault("num_heads", 1)
         attn_kwargs.setdefault("dropout", self.dropout)
         attn_kwargs.setdefault("batch_first", True)
         self.attn_kwargs = attn_kwargs
+
+        # Force the `embed_dim` to be the same as the `in_dim`
+        attn_kwargs.setdefault("embed_dim", self.in_dim)
+        if force_consistent_in_dim:
+            embed_dim = attn_kwargs["embed_dim"]
+            # assert embed_dim == self.in_dim, f"embed_dim={embed_dim} must be equal to in_dim={self.in_dim}"
 
         # Initialize the Attention layer
         attn_layer, attn_class = None, None


### PR DESCRIPTION
## Changelogs

- Added `embed_dim` to the list of keys to look for when doing the mup kwargs

@maciej-sypetkowski I think this should fix your issue, although I can't verify it because on my end, when I use the config with `architecture.mup_scale_factor: 2` it works. Basically, I can't reproduce because I don't know how you do your scaling for it to fail, but at least the `attn_layer` keys in `mup_base_params.yaml` are no longer `null`.

## IMPORTANT
when this PR closes, it will affect the reproducibility of your models if they use `AttentionLayerMup`, such as `GPSLayerPyg` since the mup will affect the learning rate of these layers, whether they were previously ignored.