### PR TITLE
Re-order atoms and edges when matching molecules from different datasets

### DIFF
--- a/graphium/data/datamodule.py
+++ b/graphium/data/datamodule.py
@@ -1094,9 +1094,13 @@ class MultitaskFromSmilesDataModule(BaseDataModule, IPUDataModuleModifier):
                 this_rank = all_canonical_ranks[ii]
 
                 # If the ranks are different, we need to store them
-                if (featurized_rank is not None) and (this_rank is not None) \
-                    and (len(featurized_rank) > 0) and (len(this_rank) > 0) and \
-                        (featurized_rank != this_rank):
+                if (
+                    (featurized_rank is not None)
+                    and (this_rank is not None)
+                    and (len(featurized_rank) > 0)
+                    and (len(this_rank) > 0)
+                    and (featurized_rank != this_rank)
+                ):
                     canonical_ranks_pair.append((featurized_rank, this_rank))
             else:
                 canonical_ranks_pair.append(None)
@@ -1126,7 +1130,16 @@ class MultitaskFromSmilesDataModule(BaseDataModule, IPUDataModuleModifier):
                 if did_featurization_fail(feat) or found_size_mismatch(task, feat, labels, smiles):
                     idx_none.append(idx)
             this_unique_ids = all_unique_mol_ids[idx_per_task[task][0] : idx_per_task[task][1]]
-            df, features, smiles, labels, sample_idx, extras, this_unique_ids, canonical_rank_pairs = self._filter_none_molecules(
+            (
+                df,
+                features,
+                smiles,
+                labels,
+                sample_idx,
+                extras,
+                this_unique_ids,
+                canonical_rank_pairs,
+            ) = self._filter_none_molecules(
                 idx_none,
                 task_df[task],
                 args["features"],
@@ -1135,7 +1148,7 @@ class MultitaskFromSmilesDataModule(BaseDataModule, IPUDataModuleModifier):
                 args["sample_idx"],
                 args["extras"],
                 this_unique_ids,
-                args["canonical_rank_pairs"]
+                args["canonical_rank_pairs"],
             )
             task_dataset_args[task]["smiles"] = smiles
             task_dataset_args[task]["labels"] = labels

--- a/graphium/data/datamodule.py
+++ b/graphium/data/datamodule.py
@@ -66,12 +66,11 @@ from graphium.data.smiles_transform import (
     did_featurization_fail,
     BatchingSmilesTransform,
     smiles_to_unique_mol_ids_and_rank,
-    get_canonical_ranks_pair,
 )
 from graphium.data.collate import graphium_collate_fn
 import graphium.data.dataset as Datasets
 from graphium.data.normalization import LabelNormalization
-from graphium.data.multilevel_utils import extract_labels
+from graphium.data.multilevel_utils import extract_labels, get_canonical_ranks_pair
 from graphium.utils.enums import TaskLevel
 
 torch.multiprocessing.set_sharing_strategy("file_system")

--- a/graphium/data/datamodule.py
+++ b/graphium/data/datamodule.py
@@ -1052,7 +1052,7 @@ class MultitaskFromSmilesDataModule(BaseDataModule, IPUDataModuleModifier):
             task_dataset_args[task]["sample_idx"] = sample_idx
             task_dataset_args[task]["extras"] = extras
 
-        """Convert SMILES to features (graphs, fingerprints, etc.) for the unique molecules found."""
+        """Convert SMILES to feature graphs for the unique molecules found."""
         all_smiles = []
         all_tasks = []
         idx_per_task = {}
@@ -1517,7 +1517,7 @@ class MultitaskFromSmilesDataModule(BaseDataModule, IPUDataModuleModifier):
     # Cannot be used as is for the multitask version, because sample_idx does not apply.
     def _featurize_molecules(self, smiles: Iterable[str]) -> Tuple[List, List]:
         """
-        Precompute the features (graphs, fingerprints, etc.) from the SMILES.
+        Precompute the features graphs from the SMILES.
         Features are computed from `self.smiles_transformer`.
         A warning is issued to mention which molecules failed featurization.
 
@@ -2658,7 +2658,7 @@ class FakeDataModule(MultitaskFromSmilesDataModule):
             task_dataset_args[task]["sample_idx"] = sample_idx
             task_dataset_args[task]["extras"] = extras
 
-        """Convert SMILES to features (graphs, fingerprints, etc.) for the unique molecules found."""
+        """Convert SMILES to feature graphs for the unique molecules found."""
         all_smiles = []
         idx_per_task = {}
         total_len = 0

--- a/graphium/data/datamodule.py
+++ b/graphium/data/datamodule.py
@@ -71,7 +71,7 @@ from graphium.data.smiles_transform import (
 from graphium.data.collate import graphium_collate_fn
 import graphium.data.dataset as Datasets
 from graphium.data.normalization import LabelNormalization
-from graphium.data.multilevel_utils import extract_labels.
+from graphium.data.multilevel_utils import extract_labels
 from graphium.utils.enums import TaskLevel
 
 torch.multiprocessing.set_sharing_strategy("file_system")

--- a/graphium/data/dataset.py
+++ b/graphium/data/dataset.py
@@ -151,7 +151,11 @@ class SingleTaskDataset(Dataset):
         return state
 
     @staticmethod
-    def reorder_labels(labels, canonical_rank_pairs: List[Tuple[Optional[List[int]], Optional[List[int]]]], task_level: TaskLevel) -> List[Any]:
+    def reorder_labels(
+        labels,
+        canonical_rank_pairs: List[Tuple[Optional[List[int]], Optional[List[int]]]],
+        task_level: TaskLevel,
+    ) -> List[Any]:
         """
         Reorder the labels according to the canonical rank pairs.
         This is useful for tasks such as node/edge/nodepair classification where the order of the nodes is important.

--- a/graphium/data/dataset.py
+++ b/graphium/data/dataset.py
@@ -163,17 +163,18 @@ class SingleTaskDataset(Dataset):
             task_level: The level of the task. One of "graph", "node", "edge", "nodepair"
         """
         if task_level not in ("graph", "node", "edge", "nodepair"):
-            raise ValueError(f"task_level must be one of 'graph', 'node', 'edge', 'nodepair', got {task_level}")
+            raise ValueError(
+                f"task_level must be one of 'graph', 'node', 'edge', 'nodepair', got {task_level}"
+            )
 
         if (canonical_rank_pairs is None) or (task_level == "graph"):
             return labels
         else:
             reordered_labels = []
             for i in range(len(labels)):
-                if (canonical_rank_pairs[i] is None):
+                if canonical_rank_pairs[i] is None:
                     reordered_labels.append(labels[i])
                 else:
-
                     # Map the indices from `b` (original molecule) to `a` (featurized molecule)
                     a, b = canonical_rank_pairs[i]
                     index_map = {value: index for index, value in enumerate(b)}
@@ -183,9 +184,13 @@ class SingleTaskDataset(Dataset):
                         reordered_labels.append(labels[i][mapped_indices])
                         # TODO: Not sure that the mapping is done on the right indices
                     elif task_level == "edge":
-                        raise NotImplementedError("Reordering of edge labels is not implemented yet. Need to figure out how to do this efficiently.")
+                        raise NotImplementedError(
+                            "Reordering of edge labels is not implemented yet. Need to figure out how to do this efficiently."
+                        )
                     elif task_level == "nodepair":
-                        raise NotImplementedError("Reordering of nodepair labels is not implemented yet. Need to figure out how to do this efficiently.")
+                        raise NotImplementedError(
+                            "Reordering of nodepair labels is not implemented yet. Need to figure out how to do this efficiently."
+                        )
 
             return reordered_labels
 

--- a/graphium/data/multilevel_utils.py
+++ b/graphium/data/multilevel_utils.py
@@ -19,8 +19,10 @@ from typing import List
 import itertools
 import math
 
+from graphium.utils.enums import TaskLevel
 
-def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
+
+def extract_labels(df: pd.DataFrame, task_level: TaskLevel, label_cols: List[str]):
     """Extracts labels in label_cols from dataframe df for a given task_level.
     Returns a list of numpy arrays converted to the correct shape. Multiple
     targets are concatenated for each graph.
@@ -60,6 +62,6 @@ def extract_labels(df: pd.DataFrame, task_level: str, label_cols: List[str]):
     unpacked_df: pd.DataFrame = df[label_cols].apply(unpack_column)
     output = unpacked_df.apply(merge_columns, axis="columns").to_list()
 
-    if task_level == "graph":
+    if task_level == task_level.GRAPH:
         return np.concatenate(output)
     return output

--- a/graphium/data/smiles_transform.py
+++ b/graphium/data/smiles_transform.py
@@ -137,7 +137,9 @@ def smiles_to_unique_mol_ids_and_rank(
     return unique_mol_ids, canonical_ranks
 
 
-def get_canonical_ranks_pair(all_canonical_ranks: List[List[int]], all_task_levels: List[TaskLevel], unique_ids_inv: Iterable[int]) -> List[Optional[Tuple[List[int], List[int]]]]:
+def get_canonical_ranks_pair(
+    all_canonical_ranks: List[List[int]], all_task_levels: List[TaskLevel], unique_ids_inv: Iterable[int]
+) -> List[Optional[Tuple[List[int], List[int]]]]:
     """
     This function takes a list of canonical ranks and task levels and returns a list of canonical ranks pairs.
     The canonical ranks pairs are used to check if the featurized ranks are the same as the canonical ranks.
@@ -153,7 +155,9 @@ def get_canonical_ranks_pair(all_canonical_ranks: List[List[int]], all_task_leve
     """
 
     if {len(all_canonical_ranks)} != set(len(all_canonical_ranks), len(all_task_levels), len(unique_ids_inv)):
-        raise ValueError(f"all_canonical_ranks, all_task_levels, and unique_ids_inv must have the same length, got {len(all_canonical_ranks)}, {len(all_task_levels)}, {len(unique_ids_inv)}")
+        raise ValueError(
+            f"all_canonical_ranks, all_task_levels, and unique_ids_inv must have the same length, got {len(all_canonical_ranks)}, {len(all_task_levels)}, {len(unique_ids_inv)}"
+        )
 
     canonical_ranks_pair = []
     for ii, inv_idx in enumerate(unique_ids_inv):
@@ -174,4 +178,3 @@ def get_canonical_ranks_pair(all_canonical_ranks: List[List[int]], all_task_leve
         else:
             canonical_ranks_pair.append(None)
     return canonical_ranks_pair
-

--- a/graphium/data/smiles_transform.py
+++ b/graphium/data/smiles_transform.py
@@ -16,7 +16,6 @@ from typing import Type, List, Dict, Union, Any, Callable, Optional, Tuple, Iter
 
 import os
 import datamol as dm
-from graphium.utils.enums import TaskLevel
 
 
 def smiles_to_unique_mol_id_and_rank(smiles: str) -> Tuple[Optional[str], List[int]]:
@@ -135,46 +134,3 @@ def smiles_to_unique_mol_ids_and_rank(
     unique_mol_ids, canonical_ranks = zip(*unique_mol_ids_and_ranks)
 
     return unique_mol_ids, canonical_ranks
-
-
-def get_canonical_ranks_pair(
-    all_canonical_ranks: List[List[int]], all_task_levels: List[TaskLevel], unique_ids_inv: Iterable[int]
-) -> List[Optional[Tuple[List[int], List[int]]]]:
-    """
-    This function takes a list of canonical ranks and task levels and returns a list of canonical ranks pairs.
-    The canonical ranks pairs are used to check if the featurized ranks are the same as the canonical ranks.
-    If the featurized ranks are different, we need to store them.
-
-    Parameters:
-        all_canonical_ranks: a list of canonical ranks. The ranks are a list of integers based on `rdkit.Chem.rdmolfiles.CanonicalRankAtoms`
-        all_task_levels: a list of task levels
-        unique_ids_inv: a list of indices
-
-    Returns:
-        canonical_ranks_pair: a list of canonical ranks pairs
-    """
-
-    if {len(all_canonical_ranks)} != set(len(all_canonical_ranks), len(all_task_levels), len(unique_ids_inv)):
-        raise ValueError(
-            f"all_canonical_ranks, all_task_levels, and unique_ids_inv must have the same length, got {len(all_canonical_ranks)}, {len(all_task_levels)}, {len(unique_ids_inv)}"
-        )
-
-    canonical_ranks_pair = []
-    for ii, inv_idx in enumerate(unique_ids_inv):
-        task_level_need_rank = all_task_levels[ii] != TaskLevel.GRAPH
-        if task_level_need_rank:
-            featurized_rank = all_canonical_ranks[inv_idx]
-            this_rank = all_canonical_ranks[ii]
-
-            # If the ranks are different, we need to store them
-            if (
-                (featurized_rank is not None)
-                and (this_rank is not None)
-                and (len(featurized_rank) > 0)
-                and (len(this_rank) > 0)
-                and (featurized_rank != this_rank)
-            ):
-                canonical_ranks_pair.append((featurized_rank, this_rank))
-        else:
-            canonical_ranks_pair.append(None)
-    return canonical_ranks_pair

--- a/graphium/data/smiles_transform.py
+++ b/graphium/data/smiles_transform.py
@@ -30,6 +30,9 @@ def smiles_to_unique_mol_id_and_rank(smiles: str) -> Tuple[Optional[str], List[i
     mol_id = ""
     try:
         mol = dm.to_mol(mol=smiles)
+        # ERROR DO NOT MERGE THIS!!
+        # WITH ORDERED=TRUE, THE CANONICAL RANKING IS THE ONE FROM THE ATOM MAPS!!
+        # DO NOT MERGE!!
         mol_id = dm.unique_id(mol)
         canonical_rank = dm.canonical_rank(mol)
     except:

--- a/graphium/data/smiles_transform.py
+++ b/graphium/data/smiles_transform.py
@@ -16,6 +16,7 @@ from typing import Type, List, Dict, Union, Any, Callable, Optional, Tuple, Iter
 
 import os
 import datamol as dm
+from graphium.utils.enums import TaskLevel
 
 
 def smiles_to_unique_mol_id_and_rank(smiles: str) -> Tuple[Optional[str], List[int]]:
@@ -134,3 +135,43 @@ def smiles_to_unique_mol_ids_and_rank(
     unique_mol_ids, canonical_ranks = zip(*unique_mol_ids_and_ranks)
 
     return unique_mol_ids, canonical_ranks
+
+
+def get_canonical_ranks_pair(all_canonical_ranks: List[List[int]], all_task_levels: List[TaskLevel], unique_ids_inv: Iterable[int]) -> List[Optional[Tuple[List[int], List[int]]]]:
+    """
+    This function takes a list of canonical ranks and task levels and returns a list of canonical ranks pairs.
+    The canonical ranks pairs are used to check if the featurized ranks are the same as the canonical ranks.
+    If the featurized ranks are different, we need to store them.
+
+    Parameters:
+        all_canonical_ranks: a list of canonical ranks. The ranks are a list of integers based on `rdkit.Chem.rdmolfiles.CanonicalRankAtoms`
+        all_task_levels: a list of task levels
+        unique_ids_inv: a list of indices
+
+    Returns:
+        canonical_ranks_pair: a list of canonical ranks pairs
+    """
+
+    if {len(all_canonical_ranks)} != set(len(all_canonical_ranks), len(all_task_levels), len(unique_ids_inv)):
+        raise ValueError(f"all_canonical_ranks, all_task_levels, and unique_ids_inv must have the same length, got {len(all_canonical_ranks)}, {len(all_task_levels)}, {len(unique_ids_inv)}")
+
+    canonical_ranks_pair = []
+    for ii, inv_idx in enumerate(unique_ids_inv):
+        task_level_need_rank = all_task_levels[ii] != TaskLevel.GRAPH
+        if task_level_need_rank:
+            featurized_rank = all_canonical_ranks[inv_idx]
+            this_rank = all_canonical_ranks[ii]
+
+            # If the ranks are different, we need to store them
+            if (
+                (featurized_rank is not None)
+                and (this_rank is not None)
+                and (len(featurized_rank) > 0)
+                and (len(this_rank) > 0)
+                and (featurized_rank != this_rank)
+            ):
+                canonical_ranks_pair.append((featurized_rank, this_rank))
+        else:
+            canonical_ranks_pair.append(None)
+    return canonical_ranks_pair
+

--- a/graphium/features/featurizer.py
+++ b/graphium/features/featurizer.py
@@ -631,6 +631,7 @@ def get_mol_edge_features(
 
     return prop_dict
 
+
 def smiles_to_node_ordering(mol: dm.Mol) -> List[int]:
     r"""
     Get the node ordering of a molecule from the "molAtomMapNumber" property.
@@ -647,7 +648,9 @@ def smiles_to_node_ordering(mol: dm.Mol) -> List[int]:
             node_ordering.append(int(atom.GetProp("molAtomMapNumber")))
         else:
             smiles = dm.to_smiles(mol, canonical=False, isomeric=False)
-            raise ValueError(f"Molecule has no atom map number. \nsmiles: {smiles} \natom: {atom.GetSymbol()}")
+            raise ValueError(
+                f"Molecule has no atom map number. \nsmiles: {smiles} \natom: {atom.GetSymbol()}"
+            )
     return node_ordering
 
 

--- a/graphium/features/featurizer.py
+++ b/graphium/features/featurizer.py
@@ -632,28 +632,6 @@ def get_mol_edge_features(
     return prop_dict
 
 
-def smiles_to_node_ordering(mol: dm.Mol) -> List[int]:
-    r"""
-    Get the node ordering of a molecule from the "molAtomMapNumber" property.
-    This property is available when using an ordered smiles rather than a regular smiles.
-
-    Parameters:
-
-    """
-    atoms = list(mol.GetAtoms())
-
-    node_ordering = []
-    for atom in atoms:
-        if atom.HasProp("molAtomMapNumber"):
-            node_ordering.append(int(atom.GetProp("molAtomMapNumber")))
-        else:
-            smiles = dm.to_smiles(mol, canonical=False, isomeric=False)
-            raise ValueError(
-                f"Molecule has no atom map number. \nsmiles: {smiles} \natom: {atom.GetSymbol()}"
-            )
-    return node_ordering
-
-
 def mol_to_adj_and_features(
     mol: Union[str, dm.Mol],
     atom_property_list_onehot: List[str] = [],
@@ -763,13 +741,6 @@ def mol_to_adj_and_features(
         conf_dict:
             contains the 3d positions of a conformer of the molecule or 0s if none is found
 
-        node_ordering:
-            The ordering of the nodes in the graph. This is useful to keep track of
-            the original ordering of the nodes in the molecule, in case of
-            node-level, edge-level or nodepair-level predictions. The ordering is determined
-            by
-            In the case of graph-level predictions, this is not needed and returns `None`.
-
     """
 
     if isinstance(mol, str):
@@ -816,14 +787,7 @@ def mol_to_adj_and_features(
         pe_val = np.asarray(pe_val, dtype=dtype)
         pe_dict[pe_key] = _mask_nans_inf(mask_nan, pe_val, pe_key)
 
-    # Get the node ordering
-    node_ordering = None
-    atoms = list(mol.GetAtoms())
-    all_prop_names = set(sum([list(atom.GetPropNames()) for atom in atoms], []))
-    if "molAtomMapNumber" in all_prop_names:
-        node_ordering = torch.as_tensor(smiles_to_node_ordering(mol), dtype=torch.int16)
-
-    return adj, ndata, edata, pe_dict, conf_dict, node_ordering
+    return adj, ndata, edata, pe_dict, conf_dict
 
 
 def mol_to_adjacency_matrix(
@@ -1116,7 +1080,6 @@ def mol_to_graph_dict(
             edata,
             pe_dict,
             conf_dict,
-            node_ordering,
         ) = mol_to_adj_and_features(
             mol=mol,
             atom_property_list_onehot=atom_property_list_onehot,
@@ -1163,10 +1126,6 @@ def mol_to_graph_dict(
     # put the conformer positions here
     for key, val in conf_dict.items():
         graph_dict["data"][key] = val
-
-    # Put the node ordering, if available
-    if node_ordering is not None:
-        graph_dict["data"]["_node_ordering"] = node_ordering
 
     graph_dict = GraphDict(graph_dict)
     return graph_dict

--- a/graphium/nn/ensemble_layers.py
+++ b/graphium/nn/ensemble_layers.py
@@ -454,5 +454,5 @@ class EnsembleMLP(MLP):
         r"""
         Controls how the class is printed
         """
-        rep = super().__repr__()
-        rep = rep[:-1] + f", num_ensemble={self.layers[0].linear.weight.shape[0]})"
+        rep = rep[:-1] + f", num_ensemble={self.fully_connected[0].linear.weight.shape[0]})"
+        return rep

--- a/graphium/utils/enums.py
+++ b/graphium/utils/enums.py
@@ -1,9 +1,11 @@
 from typing import Union
 from enum import Enum
 
+
 class TaskLevel(Enum):
     """Enum for the task level of a dataset. Options are graph, node, edge, nodepair."""
-    GRAPH = 1 # Default
+
+    GRAPH = 1  # Default
     NODE = 2
     EDGE = 3
     NODEPAIR = 4

--- a/graphium/utils/enums.py
+++ b/graphium/utils/enums.py
@@ -1,3 +1,16 @@
+"""
+--------------------------------------------------------------------------------
+Copyright (c) 2023 Valence Labs, Recursion Pharmaceuticals.
+
+Use of this software is subject to the terms and conditions outlined in the LICENSE file.
+Unauthorized modification, distribution, or use is prohibited. Provided 'as is' without
+warranties of any kind.
+
+Valence Labs, Recursion Pharmaceuticals are not liable for any damages arising from its use.
+Refer to the LICENSE file for the full terms and conditions.
+--------------------------------------------------------------------------------
+"""
+
 from typing import Union
 from enum import Enum
 

--- a/graphium/utils/enums.py
+++ b/graphium/utils/enums.py
@@ -1,0 +1,23 @@
+from typing import Union
+from enum import Enum
+
+class TaskLevel(Enum):
+    """Enum for the task level of a dataset. Options are graph, node, edge, nodepair."""
+    GRAPH = 1 # Default
+    NODE = 2
+    EDGE = 3
+    NODEPAIR = 4
+
+    def __str__(self):
+        return self.name.lower()
+
+    @staticmethod
+    def from_str(label: Union[str, "TaskLevel", type(None)]) -> "TaskLevel":
+        """
+        Converts a string to a TaskLevel enum. If label is None, returns TaskLevel.GRAPH. If label is already a TaskLevel enum, returns label.
+        """
+        if label is None:
+            return TaskLevel.GRAPH
+        if isinstance(label, TaskLevel):
+            return label
+        return TaskLevel[label.upper()]

--- a/tests/test_canonical_reordering.py
+++ b/tests/test_canonical_reordering.py
@@ -16,15 +16,19 @@ Refer to the LICENSE file for the full terms and conditions.
 Unit tests for the implementation of canonical reordering of molecules in `dataset.py` and `datamodule.py`
 """
 
+from typing import Literal
+
 import unittest as ut
 from copy import deepcopy
 import torch.nn as nn
 import torch
-
-from torch_geometric.data import Batch, Data
+import numpy as np
+import pandas as pd
+import datamol as dm
 
 from graphium.utils.enums import TaskLevel as TL
 from graphium.data.multilevel_utils import get_canonical_ranks_pair
+from graphium.data.dataset import SingleTaskDataset
 
 
 class test_task_level(ut.TestCase):
@@ -100,6 +104,89 @@ class test_node_reordering(ut.TestCase):
                 None,
             ],
         )
+
+    def test_labels_reordering(self):
+
+        labels = list(torch.randn(6, 3))
+        all_canonical_ranks = [[1, 2, 3], [2, 3, 1], [3, 2, 1], [1, 2, 3], None, [2, 3, 1]]
+        unique_ids_inv = [0, 0, 0, 0, 0, 0]
+        task_level = TL.NODE
+        all_task_levels = [task_level for _ in range(len(all_canonical_ranks))]
+        canonical_ranks_pair = get_canonical_ranks_pair(all_canonical_ranks, all_task_levels, unique_ids_inv)
+        reordered_labels = SingleTaskDataset.reorder_labels(labels, canonical_ranks_pair, task_level)
+
+        self.assertListEqual(labels[0].tolist(), reordered_labels[0].tolist())
+        self.assertListEqual(labels[1].tolist(), reordered_labels[1][[1, 2, 0]].tolist())
+        self.assertListEqual(labels[2].tolist(), reordered_labels[2][[2, 1, 0]].tolist())
+        self.assertListEqual(labels[3].tolist(), reordered_labels[3].tolist())
+        self.assertListEqual(labels[4].tolist(), reordered_labels[4].tolist())
+        self.assertListEqual(labels[5].tolist(), reordered_labels[5][[1, 2, 0]].tolist())
+
+    def test_datamodule_reordering(self):
+
+        # Make a dummy molecular dataset
+        smiles = ["C", "CC", "CCC", "CCCC", "CCCCC", "CCCCCC", "CCCCCCC"]
+        labels = [np.random.randn(len(s)) for s in smiles]
+        mols = [dm.to_mol(s) for s in smiles]
+        ordered_smiles = [dm.to_smiles(m, canonical=False, with_atom_indices=True) for m in mols]
+
+        # Reorder the molecules randomly
+        np.random.seed(42)
+        reordering_idx = [np.random.permutation(len(s)) for s in smiles]
+        reordered_mols = [reorder_atoms_to_desired(m, idx.tolist()) for m, idx in zip(mols, reordering_idx)]
+        reordered_smiles = [dm.to_smiles(m, canonical=False, with_atom_indices=True) for m in reordered_mols]
+
+
+        pass
+
+
+def ordered_carbon_smiles_generator(num_carbons, order: Literal["increasing", "random"]) -> str:
+    """Generate a list of smiles with a specified number of carbons in the molecule.
+
+    Args:
+        num_carbons: The number of carbons in the molecule.
+        order: The order of the carbons in the molecule. Either "increasing" or "random".
+
+    Returns:
+        smiles: A list of smiles with the specified number of carbons in the molecule.
+    """
+    if num_carbons == 1:
+        return "[CH4:0]"
+    elif num_carbons == 2:
+        return "[CH3:0][CH3:1]"
+    elif num_carbons > 2:
+
+        if order == "increasing":
+            return "".join([f"[CH3:{i}]" for i in range(num_carbons)])
+        elif order == "random":
+            idx = np.random.permutation(num_carbons)
+            return "".join([f"[CH3:{idx[i]}]" for i in range(num_carbons)])
+        else:
+            raise ValueError(f"Unknown order: {order}")
+
+
+
+
+from typing import List, Optional, Iterable
+from rdkit.Chem import Mol, rdmolops
+def reorder_atoms_to_desired(
+    mol: Mol,
+    desired_order: Iterable[int],
+) -> Optional[Mol]:
+    """Reorder the atoms in a mol. It ensures a single atom order for the same molecule,
+    regardless of its original representation.
+
+    Args:
+        mol: a molecule.
+        desired_order: The desired order of the atoms.
+
+    Returns:
+        mol: a molecule.
+    """
+    if mol.GetNumAtoms() == 0:
+        return mol
+
+    return rdmolops.RenumberAtoms(mol, list(desired_order))
 
 
 if __name__ == "__main__":

--- a/tests/test_canonical_reordering.py
+++ b/tests/test_canonical_reordering.py
@@ -1,0 +1,106 @@
+"""
+--------------------------------------------------------------------------------
+Copyright (c) 2023 Valence Labs, Recursion Pharmaceuticals.
+
+Use of this software is subject to the terms and conditions outlined in the LICENSE file.
+Unauthorized modification, distribution, or use is prohibited. Provided 'as is' without
+warranties of any kind.
+
+Valence Labs, Recursion Pharmaceuticals are not liable for any damages arising from its use.
+Refer to the LICENSE file for the full terms and conditions.
+--------------------------------------------------------------------------------
+"""
+
+
+"""
+Unit tests for the implementation of canonical reordering of molecules in `dataset.py` and `datamodule.py`
+"""
+
+import unittest as ut
+from copy import deepcopy
+import torch.nn as nn
+import torch
+
+from torch_geometric.data import Batch, Data
+
+from graphium.utils.enums import TaskLevel as TL
+from graphium.data.multilevel_utils import get_canonical_ranks_pair
+
+
+class test_task_level(ut.TestCase):
+    def test_task_level_enum(self):
+        # Test string conversion
+        self.assertEqual(str(TL.GRAPH), "graph")
+        self.assertEqual(str(TL.NODE), "node")
+        self.assertEqual(str(TL.EDGE), "edge")
+        self.assertEqual(str(TL.NODEPAIR), "nodepair")
+
+        # Test from_str conversion with str
+        self.assertEqual(TL.from_str("graph"), TL.GRAPH)
+        self.assertEqual(TL.from_str("node"), TL.NODE)
+        self.assertEqual(TL.from_str("edge"), TL.EDGE)
+        self.assertEqual(TL.from_str("nodepair"), TL.NODEPAIR)
+
+        # Test from_str conversion with None
+        self.assertEqual(TL.from_str(None), TL.GRAPH)
+
+        # Test from_str conversion with TL
+        self.assertEqual(TL.from_str(TL.GRAPH), TL.GRAPH)
+        self.assertEqual(TL.from_str(TL.NODE), TL.NODE)
+        self.assertEqual(TL.from_str(TL.EDGE), TL.EDGE)
+        self.assertEqual(TL.from_str(TL.NODEPAIR), TL.NODEPAIR)
+
+
+class test_node_reordering(ut.TestCase):
+    def test_get_canonical_ranks_pair(self):
+        all_canonical_ranks = [[1, 2, 3], [2, 3, 1], [3, 2, 1], [1, 2, 3], None, [2, 3, 1]]
+        all_task_levels = [TL.NODE, TL.NODE, TL.EDGE, TL.NODEPAIR, TL.NODE, TL.GRAPH]
+
+        # Check when they all map to the 1st element
+        unique_ids_inv = [0, 0, 0, 0, 0, 0]
+        canonical_ranks_pair = get_canonical_ranks_pair(all_canonical_ranks, all_task_levels, unique_ids_inv)
+        self.assertListEqual(
+            canonical_ranks_pair,
+            [
+                None,
+                ([1, 2, 3], [2, 3, 1]),
+                ([1, 2, 3], [3, 2, 1]),
+                None,
+                None,
+                None,
+            ],
+        )
+
+        # Check when they all map to the 2nd element
+        unique_ids_inv = [1, 1, 1, 1, 1, 1]
+        canonical_ranks_pair = get_canonical_ranks_pair(all_canonical_ranks, all_task_levels, unique_ids_inv)
+        self.assertListEqual(
+            canonical_ranks_pair,
+            [
+                ([2, 3, 1], [1, 2, 3]),
+                None,
+                ([2, 3, 1], [3, 2, 1]),
+                ([2, 3, 1], [1, 2, 3]),
+                None,
+                None,
+            ],
+        )
+
+        # Check when they all map to the each other
+        unique_ids_inv = [0, 1, 2, 3, 4, 5]
+        canonical_ranks_pair = get_canonical_ranks_pair(all_canonical_ranks, all_task_levels, unique_ids_inv)
+        self.assertListEqual(
+            canonical_ranks_pair,
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+        )
+
+
+if __name__ == "__main__":
+    ut.main()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -16,7 +16,7 @@ import unittest as ut
 
 from graphium.data import load_micro_zinc
 from graphium.data.dataset import SingleTaskDataset, MultitaskDataset
-from graphium.data.smiles_transform import smiles_to_unique_mol_ids
+from graphium.data.smiles_transform import smiles_to_unique_mol_ids_and_rank
 from graphium.data.utils import get_keys
 
 
@@ -75,7 +75,7 @@ class Test_Multitask_Dataset(ut.TestCase):
             label_score = ds_micro_zinc_score.labels[idx]
 
             # Search for the mol id in the multitask dataset
-            mol_ids = smiles_to_unique_mol_ids([smiles])
+            mol_ids, canonical_rank = smiles_to_unique_mol_ids_and_rank([smiles])
             mol_id = mol_ids[0]
             found_idx = -1
             for i, id in enumerate(multitask_microzinc.mol_ids):
@@ -146,7 +146,7 @@ class Test_Multitask_Dataset(ut.TestCase):
             label_score = df[["score"]].iloc[idx].values[0]
 
             # Search for that molecule in the multitask dataset
-            mol_ids = smiles_to_unique_mol_ids([smiles])
+            mol_ids, canonical_rank = smiles_to_unique_mol_ids_and_rank([smiles])
             mol_id = mol_ids[0]
             found_idx = -1
             for i, id in enumerate(multitask_microzinc.mol_ids):

--- a/tests/test_featurizer.py
+++ b/tests/test_featurizer.py
@@ -212,7 +212,7 @@ class test_featurizer(ut.TestCase):
                     num_props = int(round(ii))
                     err_msg2 = err_msg + f"\n\t\texplicit_H: {explicit_H}\n\t\tii: {ii}"
 
-                    adj, ndata, edata, _, _ = mol_to_adj_and_features(
+                    adj, ndata, edata, _, _, _ = mol_to_adj_and_features(
                         mol=mol,
                         atom_property_list_onehot=np.random.choice(
                             self.atomic_onehot_props, size=num_props, replace=False


### PR DESCRIPTION
## Changelogs

- [x] Find the canonical ordering of every molecule
- [x] Find a mapping between the order of the featurized molecule, and the molecule associated to the labels
- [x] Re-order the atoms for "node"-level tasks
- [ ] Re-order the atoms for "edge"-level tasks
- [ ] Re-order the atoms for "nodepair"-level tasks.

---

_Checklist:_

- [x] Closing #467 
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

This PR is related to issue #467. It haven't been tested or run yet, it's still in draft mode. The idea is to re-order the labels for molecules that have been merged during the featurization, but for which ordering is important, such as node-level and edge-level tasks.
