### PR TITLE
MAJOR-BUG for node/edge predictions: Added ordered=True to `to_mol`

### DIFF
--- a/graphium/data/smiles_transform.py
+++ b/graphium/data/smiles_transform.py
@@ -27,7 +27,7 @@ def smiles_to_unique_mol_id(smiles: str) -> Optional[str]:
         mol_id: a string unique ID
     """
     try:
-        mol = dm.to_mol(mol=smiles)
+        mol = dm.to_mol(mol=smiles) # Doesn't need `ordered=True` because the unique_id doesn't depend on the atom order
         mol_id = dm.unique_id(mol)
     except:
         mol_id = ""

--- a/graphium/data/smiles_transform.py
+++ b/graphium/data/smiles_transform.py
@@ -27,7 +27,9 @@ def smiles_to_unique_mol_id(smiles: str) -> Optional[str]:
         mol_id: a string unique ID
     """
     try:
-        mol = dm.to_mol(mol=smiles) # Doesn't need `ordered=True` because the unique_id doesn't depend on the atom order
+        mol = dm.to_mol(
+            mol=smiles
+        )  # Doesn't need `ordered=True` because the unique_id doesn't depend on the atom order
         mol_id = dm.unique_id(mol)
     except:
         mol_id = ""

--- a/graphium/features/featurizer.py
+++ b/graphium/features/featurizer.py
@@ -743,7 +743,7 @@ def mol_to_adj_and_features(
     """
 
     if isinstance(mol, str):
-        mol = dm.to_mol(mol)
+        mol = dm.to_mol(mol, ordered=True)
 
     # Add or remove explicit hydrogens
     if explicit_H:
@@ -1071,7 +1071,7 @@ def mol_to_graph_dict(
     input_mol = mol
     try:
         if isinstance(mol, str):
-            mol = dm.to_mol(mol)
+            mol = dm.to_mol(mol, ordered=True)
         if explicit_H:
             mol = Chem.AddHs(mol)
         else:

--- a/graphium/features/properties.py
+++ b/graphium/features/properties.py
@@ -18,6 +18,7 @@ import numpy as np
 import datamol as dm
 
 from rdkit.Chem import rdMolDescriptors as rdMD
+from loguru import logger
 
 
 def get_prop_or_none(
@@ -33,6 +34,7 @@ def get_prop_or_none(
     Returns:
         The property or a list of `None` with lenght `n`.
     """
+    logger.warning("get_prop_or_none is deprecated. Use `datamol.to_fp` instead.")
     try:
         return prop(*args, **kwargs)
     except RuntimeError:
@@ -75,8 +77,10 @@ def get_props_from_mol(
 
     """
 
+    logger.warning("get_props_from_mol is deprecated. Use `datamol.to_fp` instead.")
+
     if isinstance(mol, str):
-        mol = dm.to_mol(mol)
+        mol = dm.to_mol(mol) # Doesn't need `ordered=True` because the fingerprints don't depend on the atom order
 
     if isinstance(properties, str):
         properties = [properties]

--- a/graphium/features/properties.py
+++ b/graphium/features/properties.py
@@ -80,7 +80,9 @@ def get_props_from_mol(
     logger.warning("get_props_from_mol is deprecated. Use `datamol.to_fp` instead.")
 
     if isinstance(mol, str):
-        mol = dm.to_mol(mol) # Doesn't need `ordered=True` because the fingerprints don't depend on the atom order
+        mol = dm.to_mol(
+            mol
+        )  # Doesn't need `ordered=True` because the fingerprints don't depend on the atom order
 
     if isinstance(properties, str):
         properties = [properties]

--- a/profiling/profile_mol_to_graph.py
+++ b/profiling/profile_mol_to_graph.py
@@ -67,7 +67,9 @@ def main():
 
     graphs = []
     for s in tqdm(smiles):
-        mol = dm.to_mol(s) # Doesn't need `ordered=True` because this is just to test the speed of the featurizer
+        mol = dm.to_mol(
+            s
+        )  # Doesn't need `ordered=True` because this is just to test the speed of the featurizer
         graphs.append(mol_to_graph_dict(mol, **featurizer))
 
     print(graphs[0])

--- a/profiling/profile_mol_to_graph.py
+++ b/profiling/profile_mol_to_graph.py
@@ -67,7 +67,7 @@ def main():
 
     graphs = []
     for s in tqdm(smiles):
-        mol = dm.to_mol(s)
+        mol = dm.to_mol(s) # Doesn't need `ordered=True` because this is just to test the speed of the featurizer
         graphs.append(mol_to_graph_dict(mol, **featurizer))
 
     print(graphs[0])


### PR DESCRIPTION
A major bug was discovered when working with node, nodepair and edge-level tasks. 

The bug is due to RDKIT's weird behaviour in that it takes the AtomMapping and displays them correctly, but doesn't use them as indices. Unless you specify that you want to canonicalize the molecule. In case you have AtomMaps defined, it will NOT search for a canonical form, instead it will use the AtomMaps.

Below is the weird behaviour by RDKIT, the big numbers next to the carbons are the AtomMapping that are used to order the atoms with the same ordering as the labels. The small numbers are the indices. When visualizing the molecules to validate that the code was working, I didn't not look at the intrinsic indices, but only at the big number, assuming that the indices were correct.

![image](https://github.com/datamol-io/graphium/assets/47570400/a71a0a7f-2f80-415c-a70d-9e731d95a710)

**I'm sorry for the inconvenience I have caused everyone...** This bug was discovered this morning when trying to fix #467 .

I have validated the fix experimentally. Simply adding `ordered=True` in `dm.to_mol` yields massive improvements on both the PCQM4M and the PM6 datasets. In the plots below, I randomly subsample 20k molecules and run an MPNN  model on the node-level tasks only. You can see drastic improvements. 

What surprises me is that the metrics on PCQM are not that bad, especially since it can reach r2=0.85 on the 4M large-mix dataset. This led me to believe that the ordering was correct. But as you can see here, we can reach r2=0.95 with only 20k molecules and 100 epochs.

![image](https://github.com/datamol-io/graphium/assets/47570400/472634a1-fd9f-45e9-8b01-eb0a32119265)