### PR TITLE
Access to intermediate embeddings 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "torch >=1.12",
     "typer",
     "loguru",
     "omegaconf >=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
+    "torch >=1.12",
     "typer",
     "loguru",
     "omegaconf >=2.0.0",


### PR DESCRIPTION
This change allows access to intermediate embeddings from the model.  Example of usage:

```
output, extras = model(batch, extra_return_names=["pre_task_heads"])
fingerprint_graph = extras['pre_task_heads']['graph_feat']
```