### PR TITLE
Updating dep versions for bh2 install

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -12,7 +12,7 @@ dependencies:
   - platformdirs
 
   # scientific
-  - numpy
+  - numpy == 1.26.4
   - scipy >=1.4
   - pandas >=1.0
   - scikit-learn
@@ -28,7 +28,7 @@ dependencies:
   - gcsfs >=2021.6
 
   # ML packages
-  - cuda-version == 11.2 # works also with CPU-only system.
+  - cuda-version # works also with CPU-only system.
   - pytorch >=1.12
   - lightning >=2.0
   - torchmetrics >=0.7.0,<0.11
@@ -41,7 +41,7 @@ dependencies:
   - pytorch_scatter >=2.0
 
   # chemistry
-  - rdkit
+  - rdkit == 2024.03.4
   - datamol >=0.10
   - boost # needed by rdkit
 


### PR DESCRIPTION
## Changelogs

- Pinning version of `numpy` to the latest version < 2.0. `graphium` uses the old `numpy` API and must be below version 2.0 for now.
- Unpinning the version for the `cuda-version` package. This allows for the CUDA-compatible version of `pytorch` to be installed
- Pinning the version of `rdkit` to a recent version which contains all of the required files (imports) for `graphium_cpp`

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation is a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
