### PR TITLE
Adding the gcc, gxx, pybind to the env file. Preparing for packaging

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -49,6 +49,7 @@ dependencies:
   - sympy
   - tensorboard
   - pydantic <2  # because of lightning. See https://github.com/Lightning-AI/lightning/issues/18026 and https://github.com/Lightning-AI/lightning/pull/18022
+  - pytdc
 
   # Dev
   - pytest >=6.0
@@ -70,7 +71,13 @@ dependencies:
   - markdown-include
   - mike >=1.0.0
 
+  # C++ dependencies
+  - gcc_linux-64 # I find that I need to enforce `gcc_linux-64`, but that won't work with Mac, Windows, or Arm-Linux
+  - gxx_linux-64 # I find that I need to enforce `gxx_linux-64`, but that won't work with Mac, Windows, or Arm-Linux
+  - libgcc
+  - pybind11
+  - boost
+
   - pip:
-      - lightning-graphcore # optional, for using IPUs only
       - hydra-core>=1.3.2
-      - hydra-optuna-sweeper
+      # - hydra-optuna-sweeper  Optional


### PR DESCRIPTION
## Changelogs

- Changing the `env.yml` file to contain all the gcc requirements
- Updating the install instructions

---

_Issues to resolve:_

- [ ] Currently only supports linux x64 because the `gcc` and `gxx` do not work in the env file, we need to specify `gcc_linux-64` and `gxx_linux-64`. Ideally, we want to support Win64, WinARM, Linux64, LinuxARM, Mac64, MacARM
- [ ] Weirdly, `gcc --version` and `gxx --version` don't appear in the command line. We need to rename their folders `ln -s MY_ENV_PATH/bin/x86_64-conda-linux-gnu-gcc MY_ENV_PATH/bin/gcc`, same with `gxx`.
- [ ] When in dev mode, we need to build `graphium/graphium_cpp` separately with `pybind11`, then install it with `pip install -e graphium_cpp --no-deps`. Ideally, all should be built and installed from directly `pip install -e . --no-deps`.